### PR TITLE
feat: PBI-001b 箱庭観察と介入ループを実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>god-sandbox-mvp</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1924 @@
+{
+  "name": "god-sandbox-mvp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "god-sandbox-mvp",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "three": "^0.175.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/three": "^0.184.0",
+        "@vitejs/plugin-react": "^4.4.0",
+        "typescript": "^5.8.0",
+        "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.175.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.175.0.tgz",
+      "integrity": "sha512-nNE3pnTHxXN/Phw768u0Grr7W4+rumGg/H6PgeseNJojkJtmeHJfZWi41Gp2mpXl1pg1pf1zjwR4McM1jTqkpg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "god-sandbox-mvp",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "three": "^0.175.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.184.0",
+    "@vitejs/plugin-react": "^4.4.0",
+    "typescript": "^5.8.0",
+    "vite": "^6.2.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from "./app/AppShell";
+
+export default function App() {
+  return <AppShell />;
+}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,0 +1,157 @@
+import { useEffect } from "react";
+import { ApostlePanel } from "../features/apostle/ApostlePanel";
+import { CommandConsole } from "../features/commands/CommandConsole";
+import { EventModal } from "../features/events/EventModal";
+import { WorldViewport } from "../features/sandbox/WorldViewport";
+import {
+  getAliveCharacterCount,
+  getBloodlineSummaries,
+  getDayPhase,
+  getFocusedCharacter,
+  getSeason,
+  getStartupProtectionRemaining,
+} from "../domain/world";
+import { useAppState } from "../state/appState";
+
+export function AppShell() {
+  const [state, dispatch] = useAppState();
+  const focusedCharacter = getFocusedCharacter(state);
+  const activeEventTarget = state.activeEvent
+    ? state.characters.find((character) => character.id === state.activeEvent?.targetCharacterId)
+    : undefined;
+  const bloodlines = getBloodlineSummaries(state.characters);
+  const aliveCharacterCount = getAliveCharacterCount(state);
+  const hasLivingCharacters = aliveCharacterCount > 0;
+  const protectionRemaining = getStartupProtectionRemaining(state);
+  const dayPhase = getDayPhase(state.tick);
+  const season = getSeason(state.tick);
+
+  useEffect(() => {
+    if (state.phase === "event" && !state.activeEvent) {
+      dispatch({ type: "recoverEventPhase" });
+    }
+  }, [dispatch, state.activeEvent, state.phase]);
+
+  useEffect(() => {
+    if (state.phase !== "observing" || !hasLivingCharacters || state.timeControl === "stopped") {
+      return undefined;
+    }
+
+    const intervalMs = state.timeControl === "slow" ? 2600 : 1600;
+    const timerId = window.setInterval(() => {
+      dispatch({ type: "tick" });
+    }, intervalMs);
+
+    return () => window.clearInterval(timerId);
+  }, [dispatch, hasLivingCharacters, state.phase, state.timeControl]);
+
+  return (
+    <div className="app-shell">
+      <header className="top-bar">
+        <div>
+          <p className="eyebrow">god sandbox mvp / PBI-001</p>
+          <h1>箱庭観察と重要イベント介入</h1>
+        </div>
+        <div className="top-bar__stats">
+          <span>tick {state.tick}</span>
+          <span>生存 {aliveCharacterCount}</span>
+          <span>年齢更新 {state.ageStep} 回</span>
+          <span>
+            巡り {dayPhase === "morning" ? "朝" : dayPhase === "noon" ? "昼" : "晩"} /{" "}
+            {season === "spring"
+              ? "春"
+              : season === "summer"
+                ? "夏"
+                : season === "autumn"
+                  ? "秋"
+                  : "冬"}
+          </span>
+          <span>
+            時間制御{" "}
+            {state.timeControl === "stopped"
+              ? "停止"
+              : state.timeControl === "slow"
+                ? "低速"
+                : "通常"}
+          </span>
+          <span>
+            {state.phase === "event"
+              ? "時間停止中"
+              : hasLivingCharacters
+                ? "観察進行中"
+                : "生存者なし"}
+          </span>
+        </div>
+        <div className="top-bar__controls">
+          <button
+            className={`button button--ghost ${state.timeControl === "stopped" ? "button--active" : ""}`}
+            disabled={state.phase === "event" || !hasLivingCharacters}
+            onClick={() => dispatch({ type: "setTimeControl", timeControl: "stopped" })}
+          >
+            停止
+          </button>
+          <button
+            className={`button button--ghost ${state.timeControl === "slow" ? "button--active" : ""}`}
+            disabled={state.phase === "event" || !hasLivingCharacters}
+            onClick={() => dispatch({ type: "setTimeControl", timeControl: "slow" })}
+          >
+            低速
+          </button>
+          <button
+            className={`button button--ghost ${state.timeControl === "normal" ? "button--active" : ""}`}
+            disabled={state.phase === "event" || !hasLivingCharacters}
+            onClick={() => dispatch({ type: "setTimeControl", timeControl: "normal" })}
+          >
+            通常
+          </button>
+          <button
+            className="button button--ghost"
+            disabled={state.phase === "event" || !hasLivingCharacters}
+            onClick={() => dispatch({ type: "stepTick" })}
+          >
+            1 tick
+          </button>
+        </div>
+      </header>
+
+      <main className="main-layout">
+        <section className="viewport-panel">
+          <WorldViewport
+            characters={state.characters}
+            focusCharacterId={state.focusCharacterId}
+            dayPhase={dayPhase}
+            paused={state.phase === "event"}
+            season={season}
+          />
+        </section>
+
+        <aside className="sidebar">
+          <ApostlePanel
+            apostleMessage={state.apostleMessage}
+            focusedCharacter={focusedCharacter}
+            characters={state.characters}
+            bloodlines={bloodlines}
+            latestEventSummary={state.latestEventSummary}
+            protectionRemaining={protectionRemaining}
+            hasLivingCharacters={hasLivingCharacters}
+            paused={state.phase === "event"}
+            onSelectCharacter={(characterId) => dispatch({ type: "selectFocus", characterId })}
+            onTriggerManualEvent={() => dispatch({ type: "triggerManualEvent" })}
+          />
+
+          <CommandConsole
+            disabled={state.phase === "event" || !hasLivingCharacters}
+            logs={state.logs}
+            onSubmit={(input) => dispatch({ type: "submitCommand", input })}
+          />
+        </aside>
+      </main>
+
+      <EventModal
+        event={state.activeEvent}
+        targetCharacter={activeEventTarget}
+        onResolve={(intervention) => dispatch({ type: "resolveEvent", intervention })}
+      />
+    </div>
+  );
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,94 @@
+export type Element = "Wood" | "Fire" | "Earth" | "Metal" | "Water";
+
+export type ClassRole = "Vanguard" | "Artillery" | "Support";
+
+export type YinYangBias = "Yin" | "Balanced" | "Yang";
+
+export type InterventionKind = "watch" | "bless" | "test";
+
+export type EventTrigger = "routine" | "manual" | "milestone" | "warning" | "aging" | "death";
+
+export type EventLayer = "flow" | "notable" | "intervention";
+
+export type AppPhase = "observing" | "event";
+
+export type TimeControl = "stopped" | "slow" | "normal";
+
+export type DayPhase = "morning" | "noon" | "evening";
+
+export type Season = "spring" | "summer" | "autumn" | "winter";
+
+export interface CharacterPosition {
+  x: number;
+  z: number;
+}
+
+export interface Character {
+  id: string;
+  name: string;
+  bloodlineId: string;
+  bloodlineName: string;
+  age: number;
+  lifespanRemaining: number;
+  role: ClassRole;
+  element: Element;
+  yinYang: YinYangBias;
+  alive: boolean;
+  favorite: boolean;
+  blessings: number;
+  trials: number;
+  deathReason: string | null;
+  notable: string[];
+  milestoneHistory: number[];
+  warningIssued: boolean;
+  position: CharacterPosition;
+}
+
+export interface WorldEvent {
+  id: string;
+  title: string;
+  description: string;
+  trigger: EventTrigger;
+  layer: EventLayer;
+  targetCharacterId: string;
+  targetCharacterName: string;
+}
+
+export interface EventSummary {
+  layer: EventLayer;
+  trigger: EventTrigger;
+  title: string;
+  description: string;
+  targetCharacterName: string;
+  tick: number;
+}
+
+export interface LogEntry {
+  id: string;
+  tone: "system" | "event" | "command";
+  message: string;
+}
+
+export interface BloodlineSummary {
+  id: string;
+  name: string;
+  aliveCount: number;
+  favoriteCount: number;
+  totalBlessings: number;
+  totalTrials: number;
+}
+
+export interface WorldState {
+  phase: AppPhase;
+  tick: number;
+  ageStep: number;
+  timeControl: TimeControl;
+  focusCharacterId: string;
+  characters: Character[];
+  activeEvent: WorldEvent | null;
+  latestEventSummary: EventSummary | null;
+  apostleMessage: string;
+  logs: LogEntry[];
+  logSerial: number;
+  lastInterventionTick: number;
+}

--- a/src/domain/world.ts
+++ b/src/domain/world.ts
@@ -1,0 +1,878 @@
+import type {
+  BloodlineSummary,
+  Character,
+  DayPhase,
+  EventSummary,
+  InterventionKind,
+  LogEntry,
+  Season,
+  TimeControl,
+  WorldEvent,
+  WorldState,
+} from "./types";
+
+const AGE_INTERVAL_TICKS = 4;
+const ROUTINE_FLOW_INTERVAL = 5;
+const STARTUP_GRACE_TICKS = 12;
+const INTERVENTION_COOLDOWN_TICKS = 15;
+const MILESTONE_AGES = [18, 30, 45, 60];
+const MAX_LOGS = 12;
+const EXTINCTION_LOG = "生存者がいなくなりました。箱庭時間を停止し、残された記録だけを見守ります。";
+const RECOVERY_LOG = "イベント状態が失われたため、観察状態へ復帰しました。";
+const DAY_PHASES: DayPhase[] = ["morning", "noon", "evening"];
+const SEASONS: Season[] = ["spring", "summer", "autumn", "winter"];
+
+function buildCharacters(): Character[] {
+  return [
+    {
+      id: "aki",
+      name: "Aki",
+      bloodlineId: "sol",
+      bloodlineName: "日輪",
+      age: 17,
+      lifespanRemaining: 8,
+      role: "Support",
+      element: "Wood",
+      yinYang: "Balanced",
+      alive: true,
+      favorite: true,
+      blessings: 1,
+      trials: 0,
+      deathReason: null,
+      notable: ["芽吹きを見守る"],
+      milestoneHistory: [],
+      warningIssued: false,
+      position: { x: -3.5, z: -2.2 },
+    },
+    {
+      id: "reo",
+      name: "Reo",
+      bloodlineId: "sol",
+      bloodlineName: "日輪",
+      age: 29,
+      lifespanRemaining: 6,
+      role: "Vanguard",
+      element: "Fire",
+      yinYang: "Yang",
+      alive: true,
+      favorite: false,
+      blessings: 0,
+      trials: 1,
+      deathReason: null,
+      notable: ["前線で鍛えられた"],
+      milestoneHistory: [],
+      warningIssued: false,
+      position: { x: -1.1, z: 1.9 },
+    },
+    {
+      id: "mio",
+      name: "Mio",
+      bloodlineId: "nami",
+      bloodlineName: "潮音",
+      age: 19,
+      lifespanRemaining: 5,
+      role: "Artillery",
+      element: "Water",
+      yinYang: "Yin",
+      alive: true,
+      favorite: false,
+      blessings: 0,
+      trials: 0,
+      deathReason: null,
+      notable: ["遠見の資質"],
+      milestoneHistory: [],
+      warningIssued: false,
+      position: { x: 2.1, z: -1.4 },
+    },
+    {
+      id: "ren",
+      name: "Ren",
+      bloodlineId: "nami",
+      bloodlineName: "潮音",
+      age: 52,
+      lifespanRemaining: 2,
+      role: "Support",
+      element: "Metal",
+      yinYang: "Balanced",
+      alive: true,
+      favorite: true,
+      blessings: 2,
+      trials: 2,
+      deathReason: null,
+      notable: ["古傷を抱えつつ導く"],
+      milestoneHistory: [45],
+      warningIssued: false,
+      position: { x: 3.8, z: 2.4 },
+    },
+  ];
+}
+
+function nextLog(logSerial: number, tone: LogEntry["tone"], message: string): LogEntry {
+  return {
+    id: `log-${logSerial}`,
+    tone,
+    message,
+  };
+}
+
+function pushLog(state: WorldState, tone: LogEntry["tone"], message: string): WorldState {
+  const entry = nextLog(state.logSerial + 1, tone, message);
+
+  return {
+    ...state,
+    logSerial: state.logSerial + 1,
+    logs: [entry, ...state.logs].slice(0, MAX_LOGS),
+  };
+}
+
+function createSummary(
+  layer: EventSummary["layer"],
+  trigger: EventSummary["trigger"],
+  title: string,
+  description: string,
+  targetCharacterName: string,
+  tick: number,
+): EventSummary {
+  return {
+    layer,
+    trigger,
+    title,
+    description,
+    targetCharacterName,
+    tick,
+  };
+}
+
+function applySummary(
+  state: WorldState,
+  summary: EventSummary,
+  tone: LogEntry["tone"] = "event",
+  writeLog = true,
+): WorldState {
+  const nextState: WorldState = {
+    ...state,
+    latestEventSummary: summary,
+  };
+
+  if (!writeLog) {
+    return nextState;
+  }
+
+  return pushLog(nextState, tone, `${summary.title}: ${summary.description}`);
+}
+
+function getCharacterById(characters: Character[], id: string): Character | undefined {
+  return characters.find((character) => character.id === id);
+}
+
+function hasLivingCharacters(characters: Character[]): boolean {
+  return characters.some((character) => character.alive);
+}
+
+function findAliveTarget(characters: Character[], preferredId: string): Character | undefined {
+  return (
+    characters.find((character) => character.id === preferredId && character.alive) ??
+    characters.find((character) => character.alive)
+  );
+}
+
+function normalizeName(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function findCharacterByName(characters: Character[], rawName: string): Character | undefined {
+  const normalized = normalizeName(rawName);
+
+  return characters.find((character) => normalizeName(character.name) === normalized);
+}
+
+function getInterventionTitle(trigger: WorldEvent["trigger"], target: Character) {
+  switch (trigger) {
+    case "warning":
+      return `${target.name} の命運が揺れています`;
+    case "manual":
+    default:
+      return `${target.name} に神託を降ろします`;
+  }
+}
+
+function getInterventionDescription(trigger: WorldEvent["trigger"], target: Character) {
+  switch (trigger) {
+    case "warning":
+      return `${target.name} の残寿命は ${target.lifespanRemaining}。ここでの介入が、最期の時間の意味を変えるかもしれません。`;
+    case "manual":
+    default:
+      return `使徒が ${target.name} へ意識を集中させました。開発確認用の手動イベントです。`;
+  }
+}
+
+function buildInterventionEvent(target: Character, trigger: "manual" | "warning", tick: number): WorldEvent {
+  return {
+    id: `event-${tick}-${target.id}-${trigger}`,
+    title: getInterventionTitle(trigger, target),
+    description: getInterventionDescription(trigger, target),
+    trigger,
+    layer: "intervention",
+    targetCharacterId: target.id,
+    targetCharacterName: target.name,
+  };
+}
+
+function buildAgingSummary(target: Character, tick: number): EventSummary {
+  return createSummary(
+    "flow",
+    "aging",
+    `${target.name} が静かに時を重ねました`,
+    `${target.bloodlineName} の気配をまといながら、次の節目へ少しずつ近づいています。`,
+    target.name,
+    tick,
+  );
+}
+
+function buildRoutineSummary(target: Character, tick: number): EventSummary {
+  return createSummary(
+    "flow",
+    "routine",
+    `${target.name} は日々を過ごしています`,
+    `${target.bloodlineName} の個体として穏やかな時間を重ねています。いまは観察の時間です。`,
+    target.name,
+    tick,
+  );
+}
+
+function buildMilestoneSummary(target: Character, tick: number): EventSummary {
+  return createSummary(
+    "notable",
+    "milestone",
+    `${target.name} が年齢の節目に入りました`,
+    `${target.name} は age ${target.age} となり、進路を考える下地が整いました。`,
+    target.name,
+    tick,
+  );
+}
+
+function buildWarningSummary(target: Character, tick: number): EventSummary {
+  return createSummary(
+    "notable",
+    "warning",
+    `${target.name} の命火が弱まっています`,
+    `${target.name} の残寿命は ${target.lifespanRemaining}。まだ止めずに観察できますが、見逃せない変化です。`,
+    target.name,
+    tick,
+  );
+}
+
+function buildDeathSummary(target: Character, tick: number, deathReason: string): EventSummary {
+  return createSummary(
+    "notable",
+    "death",
+    `${target.name} が生涯を終えました`,
+    deathReason,
+    target.name,
+    tick,
+  );
+}
+
+function beginEvent(state: WorldState, event: WorldEvent, apostleMessage: string): WorldState {
+  const summary = createSummary(
+    "intervention",
+    event.trigger,
+    event.title,
+    event.description,
+    event.targetCharacterName,
+    state.tick,
+  );
+
+  const withFocus: WorldState = {
+    ...state,
+    phase: "event",
+    focusCharacterId: event.targetCharacterId,
+    activeEvent: event,
+    apostleMessage,
+    latestEventSummary: summary,
+  };
+
+  return pushLog(withFocus, "event", `${event.title}: ${event.description}`);
+}
+
+function ensureObservingState(state: WorldState, apostleMessage: string, logMessage: string): WorldState {
+  const nextState = pushLog(
+    {
+      ...state,
+      phase: "observing",
+      activeEvent: null,
+      apostleMessage,
+      timeControl: state.timeControl === "normal" || state.timeControl === "slow" ? state.timeControl : "stopped",
+    },
+    "system",
+    logMessage,
+  );
+
+  return {
+    ...nextState,
+  };
+}
+
+function isWithinStartupGrace(tick: number) {
+  return tick < STARTUP_GRACE_TICKS;
+}
+
+function getDeathReason(character: Character): string {
+  if (character.trials > character.blessings) {
+    return "試練の傷を抱えたまま寿命が尽きました。";
+  }
+
+  if (character.blessings > character.trials) {
+    return "加護に包まれていても、寿命の巡りはここで尽きました。";
+  }
+
+  return "静かに寿命を迎えました。";
+}
+
+function resolveDeaths(state: WorldState): WorldState {
+  let changed = false;
+  let nextState: WorldState = state;
+  const characters = state.characters.map((character) => {
+    if (!character.alive || character.lifespanRemaining > 0) {
+      return character;
+    }
+
+    changed = true;
+    const deathReason = getDeathReason(character);
+    const summary = buildDeathSummary(character, state.tick, deathReason);
+    nextState = applySummary(nextState, summary, "system", true);
+
+    return {
+      ...character,
+      alive: false,
+      warningIssued: true,
+      deathReason,
+    };
+  });
+
+  if (!changed) {
+    return state;
+  }
+
+  nextState = {
+    ...nextState,
+    characters,
+  };
+
+  const activeFocus = findAliveTarget(nextState.characters, nextState.focusCharacterId);
+
+  if (!activeFocus) {
+    const alreadyLogged = nextState.logs.some((log) => log.message === EXTINCTION_LOG);
+    const extinctionState: WorldState = {
+      ...nextState,
+      phase: "observing",
+      activeEvent: null,
+      timeControl: "stopped",
+      apostleMessage: "使徒は静かな世界の残響を聞いています。生存者はいません。",
+    };
+
+    return alreadyLogged ? extinctionState : pushLog(extinctionState, "system", EXTINCTION_LOG);
+  }
+
+  return {
+    ...nextState,
+    focusCharacterId: activeFocus.id,
+    apostleMessage: `使徒は ${activeFocus.name} に視線を移し、箱庭の流れを見守っています。`,
+  };
+}
+
+function applyAging(state: WorldState): WorldState {
+  const nextTick = state.tick + 1;
+  const shouldAge = nextTick % AGE_INTERVAL_TICKS === 0;
+
+  if (!shouldAge) {
+    return {
+      ...state,
+      tick: nextTick,
+    };
+  }
+
+  const protectedWindow = isWithinStartupGrace(nextTick);
+  const characters = state.characters.map((character) => {
+    if (!character.alive) {
+      return character;
+    }
+
+    const nextLifespan = Math.max(0, character.lifespanRemaining - 1);
+
+    return {
+      ...character,
+      age: character.age + 1,
+      lifespanRemaining: protectedWindow ? Math.max(2, nextLifespan) : nextLifespan,
+    };
+  });
+
+  let nextState: WorldState = {
+    ...state,
+    tick: nextTick,
+    ageStep: state.ageStep + 1,
+    characters,
+  };
+
+  const flowTarget = findAliveTarget(characters, state.focusCharacterId);
+  if (flowTarget) {
+    nextState = applySummary(nextState, buildAgingSummary(flowTarget, nextTick), "system", true);
+  }
+
+  return nextState;
+}
+
+function applyNotableEvents(state: WorldState): WorldState {
+  let nextState = state;
+
+  const milestoneTarget = state.characters.find(
+    (character) =>
+      character.alive &&
+      MILESTONE_AGES.some(
+        (milestone) => milestone === character.age && !character.milestoneHistory.includes(milestone),
+      ),
+  );
+
+  if (milestoneTarget) {
+    nextState = {
+      ...nextState,
+      characters: nextState.characters.map((character) => {
+        if (character.id !== milestoneTarget.id) {
+          return character;
+        }
+
+        const milestone = MILESTONE_AGES.find((value) => value === character.age);
+        if (!milestone || character.milestoneHistory.includes(milestone)) {
+          return character;
+        }
+
+        return {
+          ...character,
+          milestoneHistory: [...character.milestoneHistory, milestone],
+        };
+      }),
+    };
+
+    nextState = applySummary(nextState, buildMilestoneSummary(milestoneTarget, state.tick), "event", true);
+    nextState = {
+      ...nextState,
+      focusCharacterId: milestoneTarget.id,
+      apostleMessage: `使徒は ${milestoneTarget.name} が節目を迎えたことを告げています。いまは観察を続ける局面です。`,
+    };
+  }
+
+  const routineTarget =
+    state.tick > 0 && state.tick % ROUTINE_FLOW_INTERVAL === 0
+      ? findAliveTarget(nextState.characters, nextState.focusCharacterId)
+      : undefined;
+
+  if (routineTarget) {
+    nextState = applySummary(nextState, buildRoutineSummary(routineTarget, state.tick), "system", true);
+    nextState = {
+      ...nextState,
+      focusCharacterId: routineTarget.id,
+      apostleMessage: `使徒は ${routineTarget.name} の日常を報告しています。まだ介入する時ではありません。`,
+    };
+  }
+
+  return nextState;
+}
+
+function reserveInterventionTarget(state: WorldState, event: WorldEvent): WorldState {
+  return {
+    ...state,
+    characters: state.characters.map((character) => {
+      if (character.id !== event.targetCharacterId) {
+        return character;
+      }
+
+      if (event.trigger === "warning") {
+        return {
+          ...character,
+          warningIssued: true,
+        };
+      }
+
+      return character;
+    }),
+  };
+}
+
+function detectIntervention(state: WorldState): WorldEvent | null {
+  if (isWithinStartupGrace(state.tick)) {
+    return null;
+  }
+
+  if (state.tick - state.lastInterventionTick < INTERVENTION_COOLDOWN_TICKS) {
+    return null;
+  }
+
+  const warningTarget = state.characters.find(
+    (character) => character.alive && character.lifespanRemaining <= 1 && !character.warningIssued,
+  );
+  if (warningTarget) {
+    return buildInterventionEvent(warningTarget, "warning", state.tick);
+  }
+
+  return null;
+}
+
+function resolveInterventionMessage(
+  event: WorldEvent,
+  intervention: InterventionKind,
+  previousCharacter: Character,
+  updatedCharacter: Character,
+): string {
+  if (intervention === "watch") {
+    return `使徒は ${updatedCharacter.name} を静かに見守り、${event.title} を記録へ刻みました。観察記録 ${previousCharacter.notable.length} → ${updatedCharacter.notable.length}。`;
+  }
+
+  if (intervention === "bless") {
+    const blessingDelta = updatedCharacter.blessings - previousCharacter.blessings;
+    const lifespanDelta = updatedCharacter.lifespanRemaining - previousCharacter.lifespanRemaining;
+    return `使徒は ${updatedCharacter.name} に加護を注ぎました。加護 ${previousCharacter.blessings} → ${updatedCharacter.blessings} (${blessingDelta >= 0 ? "+" : ""}${blessingDelta}) / 残寿命 ${previousCharacter.lifespanRemaining} → ${updatedCharacter.lifespanRemaining} (${lifespanDelta >= 0 ? "+" : ""}${lifespanDelta})。`;
+  }
+
+  return `使徒は ${updatedCharacter.name} に試練を与えました。試練 ${previousCharacter.trials} → ${updatedCharacter.trials} (+${updatedCharacter.trials - previousCharacter.trials})。`;
+}
+
+function applyIntervention(character: Character, event: WorldEvent, intervention: InterventionKind): Character {
+  if (intervention === "watch") {
+    return {
+      ...character,
+      notable: [...character.notable, `${event.title} を見届けた`].slice(-4),
+    };
+  }
+
+  if (intervention === "bless") {
+    return {
+      ...character,
+      blessings: character.blessings + 1,
+      lifespanRemaining: event.trigger === "warning" ? character.lifespanRemaining + 1 : character.lifespanRemaining,
+      warningIssued: event.trigger === "warning" ? false : character.warningIssued,
+      notable: [...character.notable, "加護を受けた"].slice(-4),
+    };
+  }
+
+  return {
+    ...character,
+    trials: character.trials + 1,
+    notable: [...character.notable, "試練を受けた"].slice(-4),
+  };
+}
+
+export function createInitialWorldState(): WorldState {
+  return {
+    phase: "observing",
+    tick: 0,
+    ageStep: 0,
+    timeControl: "stopped",
+    focusCharacterId: "aki",
+    characters: buildCharacters(),
+    activeEvent: null,
+    latestEventSummary: createSummary(
+      "notable",
+      "manual",
+      "観察は停止中です",
+      "まずは低速か 1 tick 進行で箱庭を眺めてください。起動直後は保護時間があり、いきなり介入イベントは出ません。",
+      "Aki",
+      0,
+    ),
+    apostleMessage:
+      "使徒は日輪と潮音の二つの血統を見守っています。いまは時間を止めたまま、神が観察を始めるのを待っています。",
+    logs: [
+      {
+        id: "log-0",
+        tone: "system",
+        message: "PBI-001: 箱庭観察と重要イベント介入の最小ループを開始しました。",
+      },
+    ],
+    logSerial: 0,
+    lastInterventionTick: -INTERVENTION_COOLDOWN_TICKS,
+  };
+}
+
+export function recoverStalledEventState(state: WorldState): WorldState {
+  if (state.phase === "event" && !state.activeEvent) {
+    const message = hasLivingCharacters(state.characters)
+      ? "使徒は失われた兆しを閉じ、ふたたび観察へ戻りました。"
+      : "使徒は世界の終わりを記録し、静観に戻りました。";
+
+    return ensureObservingState(state, message, RECOVERY_LOG);
+  }
+
+  return state;
+}
+
+export function advanceWorld(state: WorldState): WorldState {
+  if (state.phase === "event" && !state.activeEvent) {
+    return recoverStalledEventState(state);
+  }
+
+  if (state.phase === "event") {
+    return state;
+  }
+
+  if (!hasLivingCharacters(state.characters)) {
+    return {
+      ...state,
+      timeControl: "stopped",
+    };
+  }
+
+  let nextState = applyAging(state);
+  nextState = resolveDeaths(nextState);
+
+  if (!hasLivingCharacters(nextState.characters)) {
+    return nextState;
+  }
+
+  nextState = applyNotableEvents(nextState);
+
+  const nextEvent = detectIntervention(nextState);
+  if (!nextEvent) {
+    return nextState;
+  }
+
+  const reservedState = reserveInterventionTarget(nextState, nextEvent);
+
+  return beginEvent(
+    reservedState,
+    nextEvent,
+    `使徒は ${nextEvent.targetCharacterName} に起きた重要な分岐を読み取りました。ここだけ神の判断が必要です。`,
+  );
+}
+
+export function setTimeControl(state: WorldState, timeControl: TimeControl): WorldState {
+  if (state.phase === "event" || !hasLivingCharacters(state.characters)) {
+    return {
+      ...state,
+      timeControl: "stopped",
+    };
+  }
+
+  return {
+    ...state,
+    timeControl,
+    apostleMessage:
+      timeControl === "stopped"
+        ? "使徒は時間を止め、いま見えている兆しを静かに読み解いています。"
+        : `使徒は箱庭時間を ${timeControl === "slow" ? "低速" : "通常"} で流し始めました。`,
+  };
+}
+
+export function stepWorld(state: WorldState): WorldState {
+  if (state.phase === "event" || !hasLivingCharacters(state.characters)) {
+    return state;
+  }
+
+  return advanceWorld({
+    ...state,
+    timeControl: "stopped",
+    apostleMessage: "使徒は時間を 1 tick だけ進め、変化を読み上げています。",
+  });
+}
+
+export function selectFocus(state: WorldState, characterId: string): WorldState {
+  const target = getCharacterById(state.characters, characterId);
+  if (!target) {
+    return state;
+  }
+
+  if (!target.alive) {
+    const nextState = pushLog(state, "system", `${target.name} はすでに死亡しているため、注目対象にはできません。`);
+    return {
+      ...nextState,
+      apostleMessage: `使徒は ${target.name} ではなく、生きている個体へ視線を向けるべきだと告げています。`,
+    };
+  }
+
+  return {
+    ...state,
+    focusCharacterId: target.id,
+    apostleMessage: `使徒は ${target.name} に注目を切り替えました。${target.bloodlineName} の流れを観察しています。`,
+  };
+}
+
+export function triggerManualEvent(state: WorldState): WorldState {
+  if (state.phase === "event" && !state.activeEvent) {
+    return recoverStalledEventState(state);
+  }
+
+  if (state.phase === "event") {
+    return state;
+  }
+
+  const target = findAliveTarget(state.characters, state.focusCharacterId);
+  if (!target) {
+    return pushLog(state, "system", "手動イベントを起こせる生存者がいません。");
+  }
+
+  return beginEvent(
+    state,
+    buildInterventionEvent(target, "manual", state.tick + 1),
+    `使徒は ${target.name} の周囲に人工の兆しを生み出しました。ここでは手動イベントを優先して確認できます。`,
+  );
+}
+
+export function resolveActiveEvent(state: WorldState, intervention: InterventionKind): WorldState {
+  if (!state.activeEvent) {
+    return recoverStalledEventState(pushLog(state, "system", "いま解決すべきイベントはありません。"));
+  }
+
+  const target = getCharacterById(state.characters, state.activeEvent.targetCharacterId);
+  if (!target) {
+    return ensureObservingState(state, "使徒は対象を見失いました。", RECOVERY_LOG);
+  }
+
+  const resolvedTarget = applyIntervention(target, state.activeEvent, intervention);
+
+  const updatedCharacters = state.characters.map((character) =>
+    character.id === target.id ? resolvedTarget : character,
+  );
+
+  const resultMessage = resolveInterventionMessage(state.activeEvent, intervention, target, resolvedTarget);
+  const summary = createSummary(
+    "intervention",
+    state.activeEvent.trigger,
+    `${target.name} への介入が完了しました`,
+    resultMessage,
+    target.name,
+    state.tick,
+  );
+
+  let nextState: WorldState = {
+    ...state,
+    phase: "observing",
+    activeEvent: null,
+    focusCharacterId: target.id,
+    characters: updatedCharacters,
+    apostleMessage: resultMessage,
+    latestEventSummary: summary,
+    lastInterventionTick: state.tick,
+  };
+
+  nextState = pushLog(nextState, "command", `${intervention.toUpperCase()} -> ${target.name}: ${resultMessage}`);
+
+  return resolveDeaths(nextState);
+}
+
+export function submitCommand(state: WorldState, rawInput: string): WorldState {
+  if (state.phase === "event") {
+    const rescuedState = state.activeEvent ? state : recoverStalledEventState(state);
+    const nextState = pushLog(
+      rescuedState,
+      "system",
+      "イベント中の入力は無効です。モーダルの Watch / Bless / Test で解決してください。",
+    );
+
+    return {
+      ...nextState,
+      apostleMessage: rescuedState.activeEvent
+        ? `使徒は、先に ${rescuedState.activeEvent.targetCharacterName} への判断を求めています。`
+        : nextState.apostleMessage,
+    };
+  }
+
+  const command = rawInput.trim();
+
+  if (!command) {
+    return pushLog(state, "system", "空の命令は世界に届きませんでした。");
+  }
+
+  const [verbRaw, ...rest] = command.split(/\s+/);
+  const verb = verbRaw.toLowerCase();
+  const targetName = rest.join(" ");
+
+  if (!["watch", "bless", "test"].includes(verb)) {
+    const nextState = pushLog(
+      state,
+      "system",
+      `解釈できた命令は watch / bless / test だけです。受信: "${command}"`,
+    );
+
+    return {
+      ...nextState,
+      apostleMessage: "使徒は命令を聞き取りましたが、MVP の範囲外だと判断しました。",
+    };
+  }
+
+  const target = targetName
+    ? findCharacterByName(state.characters, targetName)
+    : getCharacterById(state.characters, state.focusCharacterId);
+
+  if (!target) {
+    const nextState = pushLog(state, "system", `対象 "${targetName}" は見つかりませんでした。`);
+    return {
+      ...nextState,
+      apostleMessage: "使徒は対象を探しましたが、該当する個体を見つけられませんでした。",
+    };
+  }
+
+  if (!target.alive) {
+    const nextState = pushLog(state, "system", `${target.name} はすでに動かぬ存在です。`);
+    return {
+      ...nextState,
+      apostleMessage: `使徒は ${target.name} に呼びかけましたが、返事はありませんでした。`,
+    };
+  }
+
+  const eventState = beginEvent(
+    {
+      ...state,
+      focusCharacterId: target.id,
+    },
+    buildInterventionEvent(target, "manual", state.tick + 1),
+    `使徒は命令 "${command}" を受け、${target.name} に向けて介入の場を整えました。`,
+  );
+
+  return pushLog(eventState, "command", `Command accepted: ${command}`);
+}
+
+export function getFocusedCharacter(state: WorldState): Character | undefined {
+  const target = getCharacterById(state.characters, state.focusCharacterId);
+  return target?.alive ? target : undefined;
+}
+
+export function getAliveCharacterCount(state: WorldState): number {
+  return state.characters.filter((character) => character.alive).length;
+}
+
+export function getStartupProtectionRemaining(state: WorldState): number {
+  return Math.max(0, STARTUP_GRACE_TICKS - state.tick);
+}
+
+export function getDayPhase(tick: number): DayPhase {
+  return DAY_PHASES[Math.floor(tick / 2) % DAY_PHASES.length];
+}
+
+export function getSeason(tick: number): Season {
+  return SEASONS[Math.floor(tick / 12) % SEASONS.length];
+}
+
+export function getBloodlineSummaries(characters: Character[]): BloodlineSummary[] {
+  const summaryMap = new Map<string, BloodlineSummary>();
+
+  for (const character of characters) {
+    const existing = summaryMap.get(character.bloodlineId);
+
+    if (existing) {
+      existing.aliveCount += character.alive ? 1 : 0;
+      existing.favoriteCount += character.favorite ? 1 : 0;
+      existing.totalBlessings += character.blessings;
+      existing.totalTrials += character.trials;
+      continue;
+    }
+
+    summaryMap.set(character.bloodlineId, {
+      id: character.bloodlineId,
+      name: character.bloodlineName,
+      aliveCount: character.alive ? 1 : 0,
+      favoriteCount: character.favorite ? 1 : 0,
+      totalBlessings: character.blessings,
+      totalTrials: character.trials,
+    });
+  }
+
+  return [...summaryMap.values()];
+}

--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -1,0 +1,145 @@
+import type { BloodlineSummary, Character, EventSummary } from "../../domain/types";
+
+interface ApostlePanelProps {
+  apostleMessage: string;
+  focusedCharacter?: Character;
+  characters: Character[];
+  bloodlines: BloodlineSummary[];
+  latestEventSummary: EventSummary | null;
+  protectionRemaining: number;
+  hasLivingCharacters: boolean;
+  paused: boolean;
+  onSelectCharacter: (characterId: string) => void;
+  onTriggerManualEvent: () => void;
+}
+
+export function ApostlePanel({
+  apostleMessage,
+  focusedCharacter,
+  characters,
+  bloodlines,
+  latestEventSummary,
+  protectionRemaining,
+  hasLivingCharacters,
+  paused,
+  onSelectCharacter,
+  onTriggerManualEvent,
+}: ApostlePanelProps) {
+  const latestNotable = focusedCharacter
+    ? focusedCharacter.notable[focusedCharacter.notable.length - 1] ?? null
+    : null;
+
+  return (
+    <section className="panel">
+      <div className="panel__heading">
+        <div>
+          <p className="eyebrow">apostle</p>
+          <h2>使徒の語り</h2>
+        </div>
+        <button
+          className="button button--ghost"
+          disabled={paused || !hasLivingCharacters}
+          onClick={onTriggerManualEvent}
+        >
+          開発: 手動イベント
+        </button>
+      </div>
+
+      <p className="narration">{apostleMessage}</p>
+
+      <div className="subpanel">
+        <div className="summary-card__header">
+          <h3>最新イベント要約</h3>
+          {latestEventSummary ? (
+            <span className={`summary-chip summary-chip--${latestEventSummary.layer}`}>
+              {latestEventSummary.layer === "flow"
+                ? "流し"
+                : latestEventSummary.layer === "notable"
+                  ? "注目"
+                  : "介入"}
+            </span>
+          ) : null}
+        </div>
+        {latestEventSummary ? (
+          <div className="summary-card">
+            <strong>{latestEventSummary.title}</strong>
+            <span>tick {latestEventSummary.tick}</span>
+            <p>{latestEventSummary.description}</p>
+          </div>
+        ) : (
+          <p>まだイベント要約はありません。</p>
+        )}
+        {protectionRemaining > 0 ? (
+          <p className="summary-note">
+            起動直後の保護時間中です。あと {protectionRemaining} tick は自動介入イベントが出ません。
+          </p>
+        ) : null}
+      </div>
+
+      {!hasLivingCharacters ? (
+        <div className="subpanel">
+          <strong>生存者はいません</strong>
+          <p>この PBI では箱庭の観察をここで停止し、残されたログだけを確認できます。</p>
+        </div>
+      ) : null}
+
+      <div className="stack">
+        <div className="subpanel">
+          <h3>注目個体</h3>
+          {focusedCharacter ? (
+            <div className="character-card character-card--focused">
+              <strong>{focusedCharacter.name}</strong>
+              <span>{focusedCharacter.bloodlineName}</span>
+              <span>
+                {focusedCharacter.role} / {focusedCharacter.element} / {focusedCharacter.yinYang}
+              </span>
+              <span>
+                age {focusedCharacter.age} / 残寿命 {focusedCharacter.lifespanRemaining}
+              </span>
+              <span>加護 {focusedCharacter.blessings} / 試練 {focusedCharacter.trials}</span>
+              {latestNotable ? <span>直近の変化: {latestNotable}</span> : null}
+            </div>
+          ) : (
+            <p>注目中の個体はいません。</p>
+          )}
+        </div>
+
+        <div className="subpanel">
+          <h3>血統サマリ</h3>
+          <div className="bloodline-grid">
+            {bloodlines.map((bloodline) => (
+              <article key={bloodline.id} className="bloodline-card">
+                <strong>{bloodline.name}</strong>
+                <span>生存 {bloodline.aliveCount}</span>
+                <span>お気に入り {bloodline.favoriteCount}</span>
+                <span>加護 {bloodline.totalBlessings}</span>
+                <span>試練 {bloodline.totalTrials}</span>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div className="subpanel">
+          <h3>個体一覧</h3>
+          <div className="character-list">
+            {characters.map((character) => (
+              <button
+                key={character.id}
+                className={`character-list__item ${
+                  focusedCharacter?.id === character.id ? "character-list__item--active" : ""
+                }`}
+                disabled={!character.alive || paused}
+                onClick={() => onSelectCharacter(character.id)}
+              >
+                <span>{character.name}</span>
+                <span>{character.alive ? "生存" : "死亡"}</span>
+                <span>{character.bloodlineName}</span>
+                {!character.alive && character.deathReason ? <span>{character.deathReason}</span> : null}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/commands/CommandConsole.tsx
+++ b/src/features/commands/CommandConsole.tsx
@@ -1,0 +1,58 @@
+import { FormEvent, useState } from "react";
+import type { LogEntry } from "../../domain/types";
+
+interface CommandConsoleProps {
+  disabled: boolean;
+  logs: LogEntry[];
+  onSubmit: (input: string) => void;
+}
+
+export function CommandConsole({ disabled, logs, onSubmit }: CommandConsoleProps) {
+  const [input, setInput] = useState("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (disabled) {
+      return;
+    }
+    onSubmit(input);
+    setInput("");
+  };
+
+  return (
+    <section className="panel">
+      <div className="panel__heading">
+        <div>
+          <p className="eyebrow">command</p>
+          <h2>神託入力</h2>
+        </div>
+        <span className="command-hint">
+          例: <code>watch Aki</code> / <code>bless</code> / <code>test Ren</code>
+        </span>
+      </div>
+
+      <form className="command-form" onSubmit={handleSubmit}>
+        <input
+          disabled={disabled}
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder={disabled ? "イベント中はモーダルから介入してください" : "watch / bless / test + 対象名"}
+        />
+        <button className="button" type="submit" disabled={disabled}>
+          送る
+        </button>
+      </form>
+
+      <div className="subpanel">
+        <h3>最近のログ</h3>
+        <ul className="log-list">
+          {logs.map((log) => (
+            <li key={log.id} className={`log-list__item log-list__item--${log.tone}`}>
+              {log.message}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -1,0 +1,67 @@
+import type { Character, InterventionKind, WorldEvent } from "../../domain/types";
+
+interface EventModalProps {
+  event: WorldEvent | null;
+  targetCharacter?: Character;
+  onResolve: (intervention: InterventionKind) => void;
+}
+
+const interventions: InterventionKind[] = ["watch", "bless", "test"];
+
+const labels: Record<InterventionKind, string> = {
+  watch: "Watch",
+  bless: "Bless",
+  test: "Test",
+};
+
+const triggerLabels: Record<WorldEvent["trigger"], string> = {
+  routine: "流しイベント",
+  manual: "手動イベント",
+  milestone: "節目",
+  warning: "警告",
+  aging: "流しイベント",
+  death: "死亡",
+};
+
+export function EventModal({ event, targetCharacter, onResolve }: EventModalProps) {
+  if (!event) {
+    return null;
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <section className="modal-card" role="dialog" aria-modal="true" aria-labelledby="event-title">
+        <div className="modal-card__media">
+          <div className="event-portrait">
+            <span>{targetCharacter?.name ?? event.targetCharacterName}</span>
+          </div>
+        </div>
+
+        <div className="modal-card__body">
+          <p className="eyebrow">important moment / {triggerLabels[event.trigger]}</p>
+          <h2 id="event-title">{event.title}</h2>
+          <p>{event.description}</p>
+
+          {targetCharacter ? (
+            <div className="event-target">
+              <span>{targetCharacter.bloodlineName}</span>
+              <span>
+                {targetCharacter.role} / {targetCharacter.element} / {targetCharacter.yinYang}
+              </span>
+              <span>
+                age {targetCharacter.age} / 残寿命 {targetCharacter.lifespanRemaining}
+              </span>
+            </div>
+          ) : null}
+          <div className="event-actions">
+            {interventions.map((intervention) => (
+              <button key={intervention} className="button" onClick={() => onResolve(intervention)}>
+                {labels[intervention]}
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/sandbox/WorldViewport.tsx
+++ b/src/features/sandbox/WorldViewport.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import type { Character, DayPhase, Season } from "../../domain/types";
+
+interface WorldViewportProps {
+  characters: Character[];
+  focusCharacterId: string;
+  dayPhase: DayPhase;
+  paused: boolean;
+  season: Season;
+}
+
+const elementColors: Record<Character["element"], number> = {
+  Wood: 0x5f9f63,
+  Fire: 0xdd6b4d,
+  Earth: 0xb68c52,
+  Metal: 0x9cb0c3,
+  Water: 0x4d7bcf,
+};
+
+export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, season }: WorldViewportProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const unitsRef = useRef<THREE.Group | null>(null);
+  const ambientLightRef = useRef<THREE.AmbientLight | null>(null);
+  const directionalLightRef = useRef<THREE.DirectionalLight | null>(null);
+  const boardRef = useRef<THREE.Mesh<THREE.PlaneGeometry, THREE.MeshStandardMaterial> | null>(null);
+
+  const dayPhaseLabel = dayPhase === "morning" ? "朝" : dayPhase === "noon" ? "昼" : "晩";
+  const seasonLabel =
+    season === "spring" ? "春" : season === "summer" ? "夏" : season === "autumn" ? "秋" : "冬";
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return undefined;
+    }
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x101826);
+
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      containerRef.current.clientWidth / Math.max(containerRef.current.clientHeight, 1),
+      0.1,
+      100,
+    );
+    camera.position.set(0, 11, 8);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(containerRef.current.clientWidth, containerRef.current.clientHeight);
+    containerRef.current.appendChild(renderer.domElement);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 1.4);
+    const directional = new THREE.DirectionalLight(0xffffff, 1.5);
+    directional.position.set(6, 12, 5);
+
+    const board = new THREE.Mesh(
+      new THREE.PlaneGeometry(14, 10),
+      new THREE.MeshStandardMaterial({ color: 0x1d3f32, roughness: 0.9, metalness: 0.05 }),
+    );
+    board.rotation.x = -Math.PI / 2;
+
+    const grid = new THREE.GridHelper(14, 14, 0x2f6470, 0x1f3341);
+    grid.position.y = 0.01;
+
+    const units = new THREE.Group();
+
+    scene.add(ambient, directional, board, grid, units);
+
+    const renderScene = () => {
+      renderer.render(scene, camera);
+    };
+
+    const handleResize = () => {
+      if (!containerRef.current) {
+        return;
+      }
+
+      const width = containerRef.current.clientWidth;
+      const height = Math.max(containerRef.current.clientHeight, 1);
+
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height);
+      renderScene();
+    };
+
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(containerRef.current);
+
+    rendererRef.current = renderer;
+    sceneRef.current = scene;
+    cameraRef.current = camera;
+    unitsRef.current = units;
+    ambientLightRef.current = ambient;
+    directionalLightRef.current = directional;
+    boardRef.current = board;
+
+    renderScene();
+
+    return () => {
+      resizeObserver.disconnect();
+      renderer.dispose();
+      scene.traverse((object: THREE.Object3D) => {
+        if (object instanceof THREE.Mesh) {
+          object.geometry.dispose();
+          if (Array.isArray(object.material)) {
+            object.material.forEach((material: THREE.Material) => material.dispose());
+          } else {
+            object.material.dispose();
+          }
+        }
+      });
+      containerRef.current?.removeChild(renderer.domElement);
+      rendererRef.current = null;
+      sceneRef.current = null;
+      cameraRef.current = null;
+      unitsRef.current = null;
+      ambientLightRef.current = null;
+      directionalLightRef.current = null;
+      boardRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    const scene = sceneRef.current;
+    const camera = cameraRef.current;
+    const ambient = ambientLightRef.current;
+    const directional = directionalLightRef.current;
+    const board = boardRef.current;
+
+    if (!renderer || !scene || !camera || !ambient || !directional || !board) {
+      return;
+    }
+
+    const backgroundByPhase: Record<DayPhase, number> = {
+      morning: 0x16263a,
+      noon: 0x1d3552,
+      evening: 0x281f31,
+    };
+
+    const ambientIntensityByPhase: Record<DayPhase, number> = {
+      morning: 1.15,
+      noon: 1.45,
+      evening: 0.95,
+    };
+
+    const directionalColorByPhase: Record<DayPhase, number> = {
+      morning: 0xf3e1bf,
+      noon: 0xffffff,
+      evening: 0xffc98f,
+    };
+
+    const boardColorBySeason: Record<Season, number> = {
+      spring: 0x29553f,
+      summer: 0x1f5f34,
+      autumn: 0x5d4a2e,
+      winter: 0x274a56,
+    };
+
+    scene.background = new THREE.Color(backgroundByPhase[dayPhase]);
+    ambient.intensity = ambientIntensityByPhase[dayPhase];
+    directional.intensity = dayPhase === "noon" ? 1.55 : 1.3;
+    directional.color = new THREE.Color(directionalColorByPhase[dayPhase]);
+    board.material.color = new THREE.Color(boardColorBySeason[season]);
+
+    renderer.render(scene, camera);
+  }, [dayPhase, season]);
+
+  useEffect(() => {
+    const units = unitsRef.current;
+    const renderer = rendererRef.current;
+    const scene = sceneRef.current;
+    const camera = cameraRef.current;
+
+    if (!units || !renderer || !scene || !camera) {
+      return;
+    }
+
+    while (units.children.length > 0) {
+      const child = units.children[0];
+      units.remove(child);
+
+      if (child instanceof THREE.Mesh) {
+        child.geometry.dispose();
+        if (Array.isArray(child.material)) {
+          child.material.forEach((material: THREE.Material) => material.dispose());
+        } else {
+          child.material.dispose();
+        }
+      }
+    }
+
+    for (const character of characters) {
+      const color = character.alive ? elementColors[character.element] : 0x6b7280;
+      const unit = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.45, 0.55, 1.2, 24),
+        new THREE.MeshStandardMaterial({
+          color,
+          emissive: character.id === focusCharacterId ? 0x14213d : 0x000000,
+          metalness: 0.15,
+          roughness: 0.45,
+        }),
+      );
+      unit.position.set(character.position.x, 0.62, character.position.z);
+      units.add(unit);
+
+      if (character.id === focusCharacterId) {
+        const ring = new THREE.Mesh(
+          new THREE.TorusGeometry(0.85, 0.06, 8, 24),
+          new THREE.MeshStandardMaterial({
+            color: paused ? 0xf6c453 : 0xffffff,
+            emissive: paused ? 0xf6c453 : 0x9ca3af,
+          }),
+        );
+        ring.rotation.x = Math.PI / 2;
+        ring.position.set(character.position.x, 0.08, character.position.z);
+        units.add(ring);
+      }
+    }
+
+    renderer.render(scene, camera);
+  }, [characters, focusCharacterId, paused]);
+
+  return (
+    <div className="viewport-root">
+      <div className="viewport-root__canvas" ref={containerRef} />
+      <div className="viewport-overlay">
+        <div className="viewport-overlay__chip">
+          <span className={paused ? "status-dot status-dot--paused" : "status-dot"} />
+          {paused ? "重要イベントで停止中" : "箱庭時間が進行中"}
+        </div>
+        <div className="viewport-overlay__chip viewport-overlay__chip--center">
+          {dayPhaseLabel} / {seasonLabel}
+        </div>
+        <div className="viewport-overlay__legend">
+          <span>木</span>
+          <span>火</span>
+          <span>土</span>
+          <span>金</span>
+          <span>水</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,428 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", "Hiragino Sans", sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background: #071018;
+  color: #e5eef9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(91, 134, 168, 0.35), transparent 32%),
+    linear-gradient(180deg, #0b1421 0%, #071018 100%);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.top-bar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid rgba(146, 175, 199, 0.16);
+  border-radius: 18px;
+  background: rgba(8, 17, 28, 0.82);
+  padding: 1rem 1.25rem;
+}
+
+.top-bar h1,
+.panel h2,
+.subpanel h3,
+.modal-card h2 {
+  margin: 0;
+}
+
+.top-bar__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  color: #9ab0c2;
+}
+
+.top-bar__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.eyebrow {
+  margin: 0 0 0.2rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #8cb0c0;
+}
+
+.main-layout {
+  display: grid;
+  flex: 1;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.95fr);
+}
+
+.viewport-panel,
+.sidebar,
+.panel,
+.subpanel {
+  min-height: 0;
+}
+
+.viewport-panel,
+.panel {
+  border: 1px solid rgba(146, 175, 199, 0.16);
+  border-radius: 18px;
+  background: rgba(8, 17, 28, 0.82);
+}
+
+.viewport-panel {
+  overflow: hidden;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.panel__heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.subpanel {
+  border: 1px solid rgba(146, 175, 199, 0.12);
+  border-radius: 14px;
+  background: rgba(20, 31, 46, 0.55);
+  padding: 0.85rem;
+}
+
+.narration {
+  margin: 0;
+  color: #d8e4f1;
+}
+
+.button {
+  border: 0;
+  border-radius: 10px;
+  background: #5d89d8;
+  color: white;
+  padding: 0.68rem 0.95rem;
+  transition: background 0.2s ease;
+}
+
+.button:hover {
+  background: #4d7bcf;
+}
+
+.button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.button--ghost:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.button--active {
+  background: rgba(93, 137, 216, 0.32);
+  outline: 1px solid rgba(93, 137, 216, 0.55);
+}
+
+.viewport-root {
+  position: relative;
+  height: 100%;
+  min-height: 520px;
+}
+
+.viewport-root__canvas {
+  height: 100%;
+  min-height: 520px;
+}
+
+.viewport-overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.viewport-overlay__chip,
+.viewport-overlay__legend {
+  align-self: flex-start;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(7, 16, 24, 0.78);
+  padding: 0.45rem 0.8rem;
+  color: #dbe6f1;
+}
+
+.viewport-overlay__chip--center {
+  align-self: flex-end;
+}
+
+.viewport-overlay__legend {
+  display: flex;
+  gap: 0.7rem;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-right: 0.45rem;
+  border-radius: 50%;
+  background: #6be18d;
+}
+
+.status-dot--paused {
+  background: #f6c453;
+}
+
+.character-card,
+.bloodline-card,
+.character-list__item,
+.event-target {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.75rem;
+}
+
+.character-card--focused {
+  border: 1px solid rgba(246, 196, 83, 0.3);
+}
+
+.summary-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.55rem;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.75rem;
+}
+
+.summary-card p {
+  margin: 0;
+}
+
+.summary-chip {
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.82rem;
+}
+
+.summary-chip--flow {
+  background: rgba(108, 156, 211, 0.18);
+  color: #bed8f8;
+}
+
+.summary-chip--notable {
+  background: rgba(246, 196, 83, 0.18);
+  color: #f6d98c;
+}
+
+.summary-chip--intervention {
+  background: rgba(107, 225, 141, 0.16);
+  color: #b4efc0;
+}
+
+.summary-note {
+  margin: 0.6rem 0 0;
+  color: #9ab0c2;
+  font-size: 0.92rem;
+}
+
+.bloodline-grid,
+.character-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.bloodline-grid {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.character-list__item {
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: #e5eef9;
+  text-align: left;
+}
+
+.character-list__item--active {
+  border-color: rgba(93, 137, 216, 0.65);
+}
+
+.character-list__item:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.command-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.7rem;
+}
+
+.command-form input {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #f4f7fb;
+  padding: 0.72rem 0.9rem;
+}
+
+.command-hint {
+  color: #9ab0c2;
+  font-size: 0.9rem;
+}
+
+.log-list {
+  display: flex;
+  max-height: 240px;
+  flex-direction: column;
+  gap: 0.55rem;
+  margin: 0;
+  overflow: auto;
+  padding: 0;
+  list-style: none;
+}
+
+.log-list__item {
+  border-left: 3px solid transparent;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.55rem 0.7rem;
+}
+
+.log-list__item--system {
+  border-left-color: #7c9ab8;
+}
+
+.log-list__item--event {
+  border-left-color: #f6c453;
+}
+
+.log-list__item--command {
+  border-left-color: #6be18d;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(2, 7, 12, 0.78);
+  padding: 1rem;
+}
+
+.modal-card {
+  display: grid;
+  width: min(900px, 100%);
+  gap: 1rem;
+  border: 1px solid rgba(146, 175, 199, 0.18);
+  border-radius: 20px;
+  background: #0c1826;
+  padding: 1rem;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+}
+
+.modal-card__media {
+  display: flex;
+}
+
+.event-portrait {
+  display: grid;
+  flex: 1;
+  place-items: center;
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at top, rgba(246, 196, 83, 0.4), transparent 35%),
+    linear-gradient(180deg, #1c2a40 0%, #0f1621 100%);
+  color: #fff4d1;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.modal-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.event-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+@media (max-width: 980px) {
+  .main-layout,
+  .modal-card {
+    grid-template-columns: 1fr;
+  }
+
+  .viewport-root,
+  .viewport-root__canvas {
+    min-height: 360px;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element was not found.");
+}
+
+createRoot(rootElement).render(<App />);

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -1,0 +1,52 @@
+import { useReducer } from "react";
+import {
+  advanceWorld,
+  createInitialWorldState,
+  recoverStalledEventState,
+  resolveActiveEvent,
+  selectFocus,
+  setTimeControl,
+  stepWorld,
+  submitCommand,
+  triggerManualEvent,
+} from "../domain/world";
+import type { InterventionKind, TimeControl, WorldState } from "../domain/types";
+
+type AppAction =
+  | { type: "tick" }
+  | { type: "stepTick" }
+  | { type: "setTimeControl"; timeControl: TimeControl }
+  | { type: "selectFocus"; characterId: string }
+  | { type: "triggerManualEvent" }
+  | { type: "submitCommand"; input: string }
+  | { type: "recoverEventPhase" }
+  | { type: "resolveEvent"; intervention: InterventionKind };
+
+function appReducer(state: WorldState, action: AppAction): WorldState {
+  const safeState = recoverStalledEventState(state);
+
+  switch (action.type) {
+    case "tick":
+      return advanceWorld(safeState);
+    case "stepTick":
+      return stepWorld(safeState);
+    case "setTimeControl":
+      return setTimeControl(safeState, action.timeControl);
+    case "selectFocus":
+      return selectFocus(safeState, action.characterId);
+    case "triggerManualEvent":
+      return triggerManualEvent(safeState);
+    case "submitCommand":
+      return submitCommand(safeState, action.input);
+    case "recoverEventPhase":
+      return recoverStalledEventState(safeState);
+    case "resolveEvent":
+      return resolveActiveEvent(safeState, action.intervention);
+    default:
+      return safeState;
+  }
+}
+
+export function useAppState() {
+  return useReducer(appReducer, undefined, createInitialWorldState);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## 変更ファイル一覧
- `index.html`
- `package-lock.json`
- `package.json`
- `src/App.tsx`
- `src/app/AppShell.tsx`
- `src/domain/types.ts`
- `src/domain/world.ts`
- `src/features/apostle/ApostlePanel.tsx`
- `src/features/commands/CommandConsole.tsx`
- `src/features/events/EventModal.tsx`
- `src/features/sandbox/WorldViewport.tsx`
- `src/index.css`
- `src/main.tsx`
- `src/state/appState.ts`
- `src/vite-env.d.ts`
- `tsconfig.json`
- `vite.config.ts`

## PBI-001b で実現したこと
- React + TypeScript + Vite + Three.js で、箱庭観察と重要イベント介入の最小ループを実装
- 2血統4人の固定 seed 個体で、観察・注目・介入の流れをローカルで確認可能にした
- `routine` を流しイベント化し、18 / 30 / 45 の節目を注目イベントとして pause なしで扱うように整理
- `warning` を主な介入イベントとして扱い、startup grace と intervention cooldown で連続 pause を抑制
- `Watch / Bless / Test` の限定介入と、イベント中の時間停止モーダルを実装
- `Watch` は見届けた内容が分かる表示、`Bless` は加護と残寿命の数値差分が分かる表示に調整
- 起動直後 pause、停止 / 低速 / 通常 / 1 tick の時間制御を追加
- 朝 / 昼 / 晩 と季節の巡りを、ヘッダー表示と箱庭ビューの最小見た目変化で表現
- all-dead 状態の明示、死亡理由表示、event phase の詰まり救済など、安全側の挙動を維持

## 今回見送った範囲
- localStorage 永続化
- 英霊化本実装
- 戦闘本実装
- 五行 / 陰陽の本格反映
- `Test` の見え方改善
- chunk size warning の解消
- README / architecture.md の更新

## ローカル確認手順
1. `npm install`
2. `npm run dev`
3. 観察確認
   - 起動直後は停止状態で始まる
   - `routine` では pause しない
   - 18 / 30 / 45 の節目は注目イベントとして表示される
   - `warning` でのみ介入モーダルが出る
4. 介入確認
   - `Watch` 後に見届けた内容が分かる
   - `Bless` 後に加護と残寿命の数値差分が出る
5. 時間表現確認
   - ヘッダーと箱庭ビューで `朝 / 昼 / 晩` が分かる
   - ヘッダーで季節が分かる
6. build 確認
   - `npm run build`

## 未解決点
- `Test` の結果表示は今回広げていません
- Vite build の chunk size warning は残っています
- 追加の PBI で localStorage / 英霊化 / 戦闘へ拡張する前提です