### PR TITLE
feat: add generic art receptacle UI for pbi-002a

### DIFF
--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -17,6 +17,15 @@ interface ApostlePanelProps {
   onTriggerManualEvent: () => void;
 }
 
+function getPortraitGuide(name?: string) {
+  return {
+    subjectLabel: "アート基準キャラ: Ryo（後続PBIで正式追加）",
+    toneLabel: name ? `仮接続先: ${name}` : "仮接続先: なし",
+    expressionLine: "推奨差分: 平静 / 気づき / 緊張 / 覚悟",
+    note: "この枠は、後で Ryo の表情差分を差し込むための generic な仮受け皿です。",
+  };
+}
+
 export function ApostlePanel({
   apostleMessage,
   focusedCharacter,
@@ -37,6 +46,7 @@ export function ApostlePanel({
     setNotesExpanded(false);
   }, [focusedCharacter?.id]);
 
+  const portraitGuide = getPortraitGuide(focusedCharacter?.name);
   const latestNotable = focusedCharacter
     ? focusedCharacter.notable[focusedCharacter.notable.length - 1] ?? null
     : null;
@@ -125,6 +135,20 @@ export function ApostlePanel({
           <p>この PBI では箱庭の観察をここで停止し、残されたログだけを確認できます。</p>
         </div>
       ) : null}
+
+      <div className="subpanel art-receptacle">
+        <div className="summary-card__header">
+          <h3>アート受け皿</h3>
+          <span className="placeholder-chip">仮枠</span>
+        </div>
+        <div className="art-slot art-slot--portrait">
+          <span className="art-slot__eyebrow">portrait slot / placeholder</span>
+          <strong>{portraitGuide.subjectLabel}</strong>
+          <span>{portraitGuide.toneLabel}</span>
+          <span>{portraitGuide.expressionLine}</span>
+          <p className="summary-note">{portraitGuide.note}</p>
+        </div>
+      </div>
 
       <div className="stack">
         <div className="subpanel">

--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -49,6 +49,26 @@ function buildRollingState(
   };
 }
 
+function getEventArtGuide(event: WorldEvent, targetCharacter?: Character) {
+  const subjectName = targetCharacter?.name ?? event.targetCharacterName;
+
+  switch (event.trigger) {
+    case "warning":
+      return {
+        portraitLine: `仮表示対象: ${subjectName} / 危機前表情を置く仮枠`,
+        illustrationLine: "Ryo 基準の感情挿絵を後差しするための仮枠",
+        shotLine: "推奨構図: 顔寄り + 背景の不穏",
+      };
+    case "manual":
+    default:
+      return {
+        portraitLine: `仮表示対象: ${subjectName} / 受け止め表情を置く仮枠`,
+        illustrationLine: "Ryo 基準のイベント挿絵を後差しするための仮枠",
+        shotLine: "推奨構図: 上空からの光 + 視線誘導",
+      };
+  }
+}
+
 export function EventModal({ event, tick, momentum, targetCharacter, onResolve }: EventModalProps) {
   const [rollingState, setRollingState] = useState<RollingState | null>(null);
   const [rollingValue, setRollingValue] = useState(1);
@@ -129,6 +149,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     event.presetIntervention === "bless" || event.presetIntervention === "test"
       ? event.presetIntervention
       : null;
+  const eventArtGuide = getEventArtGuide(event, targetCharacter);
   const activeRollingIntervention = rollingState?.intervention ?? presetPreviewIntervention;
   const isRolling =
     !!presetPreviewIntervention || rollingState?.intervention === "bless" || rollingState?.intervention === "test";
@@ -183,8 +204,16 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     <div className="modal-backdrop" role="presentation">
       <section className="modal-card" role="dialog" aria-modal="true" aria-labelledby="event-title">
         <div className="modal-card__media">
-          <div className="event-portrait">
-            <span>{targetCharacter?.name ?? event.targetCharacterName}</span>
+          <div className="art-slot art-slot--portrait">
+            <span className="art-slot__eyebrow">portrait slot / placeholder</span>
+            <strong>基準キャラ: Ryo（未接続）</strong>
+            <span>{eventArtGuide.portraitLine}</span>
+          </div>
+          <div className="art-slot art-slot--illustration">
+            <span className="art-slot__eyebrow">event illustration slot / placeholder</span>
+            <strong>{triggerLabels[event.trigger]} の挿絵仮枠</strong>
+            <span>{eventArtGuide.illustrationLine}</span>
+            <span>{eventArtGuide.shotLine}</span>
           </div>
         </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -337,6 +337,50 @@ button {
   padding: 0.65rem 0.75rem;
 }
 
+.art-receptacle {
+  gap: 0.75rem;
+}
+
+.placeholder-chip {
+  border: 1px dashed rgba(246, 196, 83, 0.45);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  color: #f6d98c;
+  font-size: 0.82rem;
+}
+
+.art-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 120px;
+  justify-content: center;
+  border: 1px dashed rgba(246, 196, 83, 0.42);
+  border-radius: 14px;
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(246, 196, 83, 0.06),
+      rgba(246, 196, 83, 0.06) 12px,
+      rgba(255, 255, 255, 0.02) 12px,
+      rgba(255, 255, 255, 0.02) 24px
+    ),
+    rgba(255, 255, 255, 0.03);
+  padding: 0.9rem;
+  color: #e9eef6;
+}
+
+.art-slot--illustration {
+  min-height: 168px;
+}
+
+.art-slot__eyebrow {
+  color: #f6d98c;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
 .event-cause {
   margin-top: 0.85rem;
 }
@@ -481,19 +525,8 @@ button {
 
 .modal-card__media {
   display: flex;
-}
-
-.event-portrait {
-  display: grid;
-  flex: 1;
-  place-items: center;
-  border-radius: 16px;
-  background:
-    radial-gradient(circle at top, rgba(246, 196, 83, 0.4), transparent 35%),
-    linear-gradient(180deg, #1c2a40 0%, #0f1621 100%);
-  color: #fff4d1;
-  font-size: 1.5rem;
-  font-weight: 700;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .modal-card__body {


### PR DESCRIPTION
## 背景
- PBI-002a として、固定1名の主要キャラ（Ryo）の表情差分とイベント挿絵を、後で差し込める最小の UI 受け皿を先に用意する PR です。
- 今回はアート基準の土台づくりを優先し、domain 層の正式なキャラ追加や世界パラメータ拡張には踏み込みません。

## 変更ファイル一覧
- `src/features/apostle/ApostlePanel.tsx`
- `src/features/events/EventModal.tsx`
- `src/index.css`

## 今回やったこと
- `ApostlePanel` に generic な portrait 受け皿を追加
- `EventModal` に generic な portrait / event illustration 受け皿を追加
- プレースホルダーだと一目で分かるように、破線・ストライプ・ `placeholder` 表記で仮枠化
- `Ryo` は UI 文言上のアート基準キャラとしてのみ扱い、domain には追加していません
- 既存キャラは仮接続先として表示し、レイアウト崩れがないことを確認しています
- 監査で指摘された `.event-portrait` の dead CSS を削除

## 常時表示の扱い
- 今回の `ApostlePanel` 側の受け皿は常時表示です
- これは意図的で、アート基準を後から差し込む位置を、観察中でも固定して確認できるようにするためです
- 条件表示への切り替えは今回の block ではなく、必要なら後続PBIで調整します

## 今回やっていないこと
- `Ryo` の正式な domain 追加
- `buildCharacters()` の変更
- `world.ts` / `types.ts` の拡張
- 実アセットの差し込みロジック
- 戦闘、英霊化、永続化、世界パラメータ拡張

## build結果
- `tsc --noEmit && vite build` 成功
- chunk size warning は残っていますが、今回は対象外です

## ローカル確認
1. `npm install`
2. `npm run dev`
3. 注目個体カードに `portrait slot / placeholder` が表示されることを確認
4. `開発: 手動イベント` で EventModal を開き、portrait / illustration の仮枠が表示されることを確認
5. Aki / Reo など既存キャラに切り替えてもレイアウトが崩れないことを確認

## 未解決点 / 後続候補
- `Ryo` の正式追加は後続PBIで扱う
- 表情差分やイベント挿絵の実アセット接続も後続PBIで扱う
- 常時表示か条件表示かの最終調整も後続PBIで見直し可能