### PR TITLE
feat: add Ryo illustration slots for PBI-002b

### DIFF
--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -51,9 +51,9 @@ function getPanelPortraitSrc(paused: boolean, latestJudgement: JudgementResult |
 function getPortraitGuide(name?: string) {
   return {
     subjectLabel: "アート基準キャラ: Ryo（後続PBIで正式追加）",
-    toneLabel: name ? `仮接続先: ${name}` : "仮接続先: なし",
+    toneLabel: name ? `現在の表示対象: ${name}` : "現在の表示対象: なし",
     expressionLine: "推奨差分: 平静 / 気づき / 緊張 / 覚悟",
-    note: "この枠は、後で Ryo の表情差分を差し込むための generic な仮受け皿です。",
+    note: "この枠は、Ryo の表情差分を後続PBIで差し替え運用できる generic な portrait 受け皿です。",
   };
 }
 
@@ -171,7 +171,7 @@ export function ApostlePanel({
       <div className="subpanel art-receptacle">
         <div className="summary-card__header">
           <h3>アート受け皿</h3>
-          <span className="placeholder-chip">仮接続</span>
+          <span className="placeholder-chip">接続済み</span>
         </div>
         <div className="art-slot art-slot--portrait art-slot--with-image">
           <img

--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -35,6 +35,12 @@ const RYO_PORTRAITS = {
   divine: "/art/portraits/ryo/ryo_divine.jpeg",
 } as const;
 
+const RYO_ILLUSTRATIONS = {
+  watch: "/art/illustrations/ryo/ryo_watch.jpeg",
+  bless: "/art/illustrations/ryo/ryo_bless.jpeg",
+  test: "/art/illustrations/ryo/ryo_test.jpeg",
+} as const;
+
 interface RollingState {
   intervention: "bless" | "test";
   judgement: JudgementResult;
@@ -63,18 +69,55 @@ function getEventArtGuide(event: WorldEvent, targetCharacter?: Character) {
   switch (event.trigger) {
     case "warning":
       return {
-        portraitLine: `仮表示対象: ${subjectName} / 危機前表情を置く仮枠`,
+        portraitLine: `表示対象: ${subjectName} / 危機前表情を表示`,
         illustrationLine: "Ryo 基準の感情挿絵を後差しするための仮枠",
         shotLine: "推奨構図: 顔寄り + 背景の不穏",
       };
     case "manual":
     default:
       return {
-        portraitLine: `仮表示対象: ${subjectName} / 受け止め表情を置く仮枠`,
+        portraitLine: `表示対象: ${subjectName} / 受け止め表情を表示`,
         illustrationLine: "Ryo 基準のイベント挿絵を後差しするための仮枠",
         shotLine: "推奨構図: 上空からの光 + 視線誘導",
       };
   }
+}
+
+function getModalIllustrationSlot(
+  activeIntervention: InterventionKind | null,
+): {
+  kind: "watch" | "bless" | "test";
+  src: string;
+  title: string;
+  note: string;
+} {
+  const kind =
+    activeIntervention === "bless" || activeIntervention === "test" ? activeIntervention : "watch";
+
+  if (kind === "bless") {
+    return {
+      kind,
+      src: RYO_ILLUSTRATIONS.bless,
+      title: "Bless illustration slot",
+      note: "加護の介入挿絵をここへ差し込みます。asset 未到着時は placeholder を維持します。",
+    };
+  }
+
+  if (kind === "test") {
+    return {
+      kind,
+      src: RYO_ILLUSTRATIONS.test,
+      title: "Test illustration slot",
+      note: "試練の介入挿絵をここへ差し込みます。asset 未到着時は placeholder を維持します。",
+    };
+  }
+
+  return {
+    kind,
+    src: RYO_ILLUSTRATIONS.watch,
+    title: "Watch illustration slot",
+    note: "観察の基準挿絵をここへ差し込みます。asset 未到着時は placeholder を維持します。",
+  };
 }
 
 function getModalPortraitSrc(params: {
@@ -119,11 +162,13 @@ function getModalPortraitSrc(params: {
 export function EventModal({ event, tick, momentum, targetCharacter, onResolve }: EventModalProps) {
   const [rollingState, setRollingState] = useState<RollingState | null>(null);
   const [rollingValue, setRollingValue] = useState(1);
+  const [illustrationLoadFailed, setIllustrationLoadFailed] = useState(false);
   const confirmLockRef = useRef(false);
 
   useEffect(() => {
     setRollingState(null);
     setRollingValue(1);
+    setIllustrationLoadFailed(false);
     confirmLockRef.current = false;
   }, [event?.id]);
 
@@ -208,7 +253,12 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     judgementPreview,
     revealed: rollingState?.revealed ?? false,
   });
+  const illustrationSlot = getModalIllustrationSlot(activeRollingIntervention);
   const testPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "test", momentum) : 0;
+
+  useEffect(() => {
+    setIllustrationLoadFailed(false);
+  }, [illustrationSlot.src]);
 
   const handleResolve = (intervention: InterventionKind) => {
     if (intervention === "watch") {
@@ -266,15 +316,35 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
             />
             <div className="art-slot__meta">
               <span className="art-slot__eyebrow">portrait slot / ryo asset preview</span>
-              <strong>基準キャラ: Ryo（未接続）</strong>
+              <strong>基準キャラ: Ryo（portrait 接続済み）</strong>
               <span>{eventArtGuide.portraitLine}</span>
             </div>
           </div>
           <div className="art-slot art-slot--illustration">
-            <span className="art-slot__eyebrow">event illustration slot / placeholder</span>
-            <strong>{triggerLabels[event.trigger]} の挿絵仮枠</strong>
-            <span>{eventArtGuide.illustrationLine}</span>
-            <span>{eventArtGuide.shotLine}</span>
+            {illustrationLoadFailed ? (
+              <>
+                <span className="art-slot__eyebrow">{illustrationSlot.title} / placeholder</span>
+                <strong>{triggerLabels[event.trigger]} の挿絵仮枠</strong>
+                <span>{illustrationSlot.note}</span>
+                <span>{eventArtGuide.illustrationLine}</span>
+                <span>{eventArtGuide.shotLine}</span>
+              </>
+            ) : (
+              <>
+                <img
+                  className="art-slot__image art-slot__image--illustration"
+                  src={illustrationSlot.src}
+                  alt={`${illustrationSlot.kind} illustration preview`}
+                  onError={() => setIllustrationLoadFailed(true)}
+                />
+                <div className="art-slot__meta">
+                  <span className="art-slot__eyebrow">{illustrationSlot.title}</span>
+                  <strong>{triggerLabels[event.trigger]} の挿絵接続</strong>
+                  <span>{illustrationSlot.note}</span>
+                  <span>{eventArtGuide.shotLine}</span>
+                </div>
+              </>
+            )}
           </div>
         </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -387,6 +387,11 @@ button {
   background: rgba(7, 16, 24, 0.7);
 }
 
+.art-slot__image--illustration {
+  aspect-ratio: 16 / 10;
+  min-height: 168px;
+}
+
 .art-slot__meta {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 概要
PBI-002b として、Ryo 1名向けの portrait / illustration 受け皿を最小差分で整備しました。

今回の目的は次の 2 点です。
- portrait 側の実接続状態に合わせて、誤解を招く `仮接続 / 未接続` ラベルを解消する
- EventModal の illustration slot に Bless / Test / Watch 用の接続口を用意し、asset 未到着時は placeholder を維持する

## 変更ファイル一覧
- `src/features/apostle/ApostlePanel.tsx`
- `src/features/events/EventModal.tsx`
- `src/index.css`

## 追加した asset の配置場所
今回新しい asset 追加はありません。既存 portrait を利用しています。
- `/art/portraits/ryo/ryo_normal.jpeg`
- `/art/portraits/ryo/ryo_tense.jpeg`
- `/art/portraits/ryo/ryo_sadness.jpeg`
- `/art/portraits/ryo/ryo_joy.jpeg`
- `/art/portraits/ryo/ryo_divine.jpeg`

illustration の接続先は先に定義していますが、現時点では実ファイル未到着です。
- `/art/illustrations/ryo/ryo_watch.jpeg`
- `/art/illustrations/ryo/ryo_bless.jpeg`
- `/art/illustrations/ryo/ryo_test.jpeg`

## portrait / illustration の切替条件
### portrait
- `ApostlePanel`
  - `paused === true` -> `ryo_tense.jpeg`
  - `latestJudgement.rank === "critical"` -> `ryo_divine.jpeg`
  - `latestJudgement.rank === "failure" || "fumble"` -> `ryo_sadness.jpeg`
  - `latestJudgement.action === "bless" && (rank === "success" || "greatSuccess")` -> `ryo_joy.jpeg`
  - それ以外 -> `ryo_normal.jpeg`
- `EventModal`
  - unrevealed / rolling 中は `test preview` と `warning` を `ryo_tense.jpeg` に固定
  - revealed 後だけ `joy / sadness / divine` に分岐

### illustration
- `Watch` -> `ryo_watch.jpeg`
- `Bless` -> `ryo_bless.jpeg`
- `Test` -> `ryo_test.jpeg`
- ただし asset 未到着時は `onError` で placeholder にフォールバック

## build 結果
- `tsc --noEmit` 成功
- `vite build` 成功
- `chunk size warning` は継続していますが、今回の範囲外です

## smoke test 結果
- portrait 側の `仮接続 / 未接続` ラベルが残っていないことを確認
- illustration は接続口を持ち、asset 未到着時に placeholder を維持するコード経路になっていることを確認
- 既存の 2 フェーズモーダル、ダイス演出、Enter 確定、観察 UI を壊していない範囲で差分を限定

## 未解決点
- illustration 実画像はまだ未到着のため、今回の UI は placeholder 維持が前提です
- portrait の `onError` フォールバックは今回未追加です
- `chunk size warning` は follow-up PBI で扱います

## follow-up 候補
- illustration 実 asset 到着後の本接続
- portrait / illustration パスマップの共通化
- asset 不在時のフォールバックルール整理