### PR TITLE
fix: keep EventModal hooks order stable

### DIFF
--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -164,6 +164,12 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
   const [rollingValue, setRollingValue] = useState(1);
   const [illustrationLoadFailed, setIllustrationLoadFailed] = useState(false);
   const confirmLockRef = useRef(false);
+  const presetPreviewIntervention =
+    event?.presetIntervention === "bless" || event?.presetIntervention === "test"
+      ? event.presetIntervention
+      : null;
+  const activeRollingIntervention = rollingState?.intervention ?? presetPreviewIntervention;
+  const illustrationSlot = getModalIllustrationSlot(activeRollingIntervention);
 
   useEffect(() => {
     setRollingState(null);
@@ -233,16 +239,15 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [rollingState]);
 
+  useEffect(() => {
+    setIllustrationLoadFailed(false);
+  }, [illustrationSlot.src]);
+
   if (!event) {
     return null;
   }
 
-  const presetPreviewIntervention =
-    event.presetIntervention === "bless" || event.presetIntervention === "test"
-      ? event.presetIntervention
-      : null;
   const eventArtGuide = getEventArtGuide(event, targetCharacter);
-  const activeRollingIntervention = rollingState?.intervention ?? presetPreviewIntervention;
   const isRolling =
     !!presetPreviewIntervention || rollingState?.intervention === "bless" || rollingState?.intervention === "test";
   const judgementPreview = rollingState?.judgement ?? null;
@@ -253,12 +258,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     judgementPreview,
     revealed: rollingState?.revealed ?? false,
   });
-  const illustrationSlot = getModalIllustrationSlot(activeRollingIntervention);
   const testPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "test", momentum) : 0;
-
-  useEffect(() => {
-    setIllustrationLoadFailed(false);
-  }, [illustrationSlot.src]);
 
   const handleResolve = (intervention: InterventionKind) => {
     if (intervention === "watch") {


### PR DESCRIPTION
## 概要
PBI-BUG-HOOKS-001 として、`EventModal.tsx` の hooks order violation による黒画面を最小差分で修正します。

今回の結論は次のとおりです。
- 黒画面はサーバー停止ではなく React runtime error
- 直接原因は `EventModal.tsx` で `if (!event) return null;` の後ろに hook が残り、観察中とイベント中で hook 数が変わること
- tick loop はイベント発火のトリガーであり、直接原因ではない

## 変更ファイル
- `src/features/events/EventModal.tsx`

## 修正内容
- `illustrationLoadFailed` reset 用 `useEffect` を early return より前へ移動
- `event === null` の時でも hook 数が変わらないように、early return 前に安全な依存値を用意
  - `presetPreviewIntervention`
  - `activeRollingIntervention`
  - `illustrationSlot`
- `illustrationLoadFailed` の reset 挙動自体は維持

## Hooks 順序違反の解消方法
修正前:
- `event === null` の時は `return null` で抜ける
- `illustrationSlot.src` 依存の `useEffect` が呼ばれない
- tick 進行で初回イベントが来た瞬間だけ hook が増える

修正後:
- `illustrationSlot.src` 依存の `useEffect` を early return 前に配置
- `event` の有無に関係なく hook の並びと本数を固定

## 確認結果
### typecheck
- `npx tsc --noEmit`
- この実行環境では `npx.cmd` が `Access is denied` だったため、等価確認として `node node_modules/typescript/bin/tsc --noEmit` を実行
- 成功

### build
- `npm run build`
- この実行環境では `npm.cmd` ラッパーが `Access is denied` だったため、等価確認として `node node_modules/vite/bin/vite.js build` を実行
- 成功

### Windows 再現確認
- Windows 上で build 済み `dist` を静的配信
- headless Chrome でページを開き、`通常` を押して tick を進行
- tick 12 で warning イベント発火を確認
- `EventModal` が開き、illustration placeholder fallback も維持
- 再現前に出ていた以下の console error は再発なし
  - `Minified React error #310`
  - `Rendered more hooks than during the previous render`
  - `React has detected a change in the order of Hooks`

## 未解決点
- `npx.cmd` / `npm.cmd` ラッパー自体はこの Codex 実行環境では `Access is denied` になるため、確認は等価な Node 直叩きで実施
- `chunk size warning` は継続しているが本件とは無関係