### PR TITLE
chore: add Ryo art path registry for PBI-OPS-ART-001

### DIFF
--- a/src/assets/artPaths.ts
+++ b/src/assets/artPaths.ts
@@ -1,0 +1,13 @@
+export const RYO_PORTRAITS = {
+  normal: "/art/portraits/ryo/ryo_normal.jpeg",
+  tense: "/art/portraits/ryo/ryo_tense.jpeg",
+  sadness: "/art/portraits/ryo/ryo_sadness.jpeg",
+  joy: "/art/portraits/ryo/ryo_joy.jpeg",
+  divine: "/art/portraits/ryo/ryo_divine.jpeg",
+} as const;
+
+export const RYO_ILLUSTRATIONS = {
+  watch: "/art/illustrations/ryo/ryo_watch.jpeg",
+  bless: "/art/illustrations/ryo/ryo_bless.jpeg",
+  test: "/art/illustrations/ryo/ryo_test.jpeg",
+} as const;


### PR DESCRIPTION
## Summary
- Add `src/assets/artPaths.ts` for Ryo portrait / illustration asset path constants
- Add `public/art/illustrations/ryo/.gitkeep`
- Keep existing UI files unchanged

## Scope
PBI-OPS-ART-001 only.

## Not included
- No `EventModal.tsx` changes
- No `ApostlePanel.tsx` changes
- No `index.css` changes
- No JSX connection changes
- No domain/state changes
- No illustration asset intake

## Checks
- `npm ci`
- `npx tsc --noEmit`