### PR TITLE
ci: run domain tests in CI for PBI-CI-TEST-001

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
             echo "No typecheck script yet."
           fi
 
+      - name: Domain tests
+        run: |
+          if [ -f package.json ] && npm run | grep -q "test:domain"; then
+            npm run test:domain
+          else
+            echo "No test:domain script yet."
+          fi
+
       - name: Lint
         run: |
           if [ -f package.json ] && npm run | grep -q "lint"; then


### PR DESCRIPTION
## Summary

PBI-CI-TEST-001: domain test を CI に組み込みます。

## Changes

- Add `Domain tests` step to the existing `build` job in `.github/workflows/ci.yml`
- Run `npm run test:domain` when the script exists
- Print `No test:domain script yet.` and skip when the script does not exist
- Keep the `guard` workflow unchanged

## Current build job order

1. Install dependencies
2. Typecheck
3. Domain tests
4. Lint
5. Build

## Scope

This PR changes CI only.

## Not included

- No UI changes
- No domain logic changes
- No test additions
- No dependency additions
- No package changes
- No guard workflow changes

## Checks

- `npm run test:domain`
  - passed
  - 1 file / 5 tests passed
- `npm run build`
  - passed
  - existing chunk size warning remains non-blocking

## Review note

This PR changes `.github/workflows/ci.yml`, so manual review is required.