### PR TITLE
refactor: use shared Ryo art paths for PBI-OPS-ART-002

### DIFF
--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { RYO_PORTRAITS } from "../../assets/artPaths";
 import { getJudgementRankLabel } from "../../domain/world";
 import type { BloodlineSummary, Character, EventSummary, JudgementResult } from "../../domain/types";
 
@@ -16,14 +17,6 @@ interface ApostlePanelProps {
   onSelectCharacter: (characterId: string) => void;
   onTriggerManualEvent: () => void;
 }
-
-const RYO_PORTRAITS = {
-  normal: "/art/portraits/ryo/ryo_normal.jpeg",
-  tense: "/art/portraits/ryo/ryo_tense.jpeg",
-  sadness: "/art/portraits/ryo/ryo_sadness.jpeg",
-  joy: "/art/portraits/ryo/ryo_joy.jpeg",
-  divine: "/art/portraits/ryo/ryo_divine.jpeg",
-} as const;
 
 function getPanelPortraitSrc(paused: boolean, latestJudgement: JudgementResult | null) {
   if (paused) {

--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { RYO_ILLUSTRATIONS, RYO_PORTRAITS } from "../../assets/artPaths";
 import { getInterventionModifier, getJudgementRankLabel, previewJudgement } from "../../domain/world";
 import type { Character, InterventionKind, JudgementResult, WorldEvent } from "../../domain/types";
 
@@ -26,20 +27,6 @@ const triggerLabels: Record<WorldEvent["trigger"], string> = {
   aging: "流しイベント",
   death: "死亡",
 };
-
-const RYO_PORTRAITS = {
-  normal: "/art/portraits/ryo/ryo_normal.jpeg",
-  tense: "/art/portraits/ryo/ryo_tense.jpeg",
-  sadness: "/art/portraits/ryo/ryo_sadness.jpeg",
-  joy: "/art/portraits/ryo/ryo_joy.jpeg",
-  divine: "/art/portraits/ryo/ryo_divine.jpeg",
-} as const;
-
-const RYO_ILLUSTRATIONS = {
-  watch: "/art/illustrations/ryo/ryo_watch.jpeg",
-  bless: "/art/illustrations/ryo/ryo_bless.jpeg",
-  test: "/art/illustrations/ryo/ryo_test.jpeg",
-} as const;
 
 interface RollingState {
   intervention: "bless" | "test";


### PR DESCRIPTION
## Summary
- replace local Ryo portrait and illustration path constants with imports from src/assets/artPaths.ts
- keep EventModal and ApostlePanel behavior unchanged
- leave illustration placeholder fallback and existing portrait switching intact

## Scope
- PBI-OPS-ART-002 only

## Checks
- npx tsc --noEmit
- npm run build
- npm run test:domain