### PR TITLE
backend: add local REST API skeleton for PBI-BE-API-001

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test:domain": "vitest run src/domain/world.test.ts"
+    "test:domain": "vitest run src/domain/world.test.ts",
+    "api:dev": "node server/rest-api.mjs"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,58 @@
+# god-sandbox-api
+
+Local REST API skeleton for development use (PBI-BE-API-001).
+
+Built with Node.js standard `http` module — no external dependencies.
+
+## Start
+
+```bash
+npm run api:dev
+# or
+PORT=8787 node server/rest-api.mjs
+```
+
+## Endpoints
+
+| Method | Path           | Description              |
+|--------|----------------|--------------------------|
+| GET    | /api/health    | Server liveness check    |
+| POST   | /api/login     | Stub login               |
+| GET    | /api/session   | Stub session check       |
+| POST   | /api/logout    | Stub logout              |
+
+### GET /api/health
+
+```json
+{ "ok": true, "service": "god-sandbox-api" }
+```
+
+### POST /api/login
+
+Request body:
+```json
+{ "playerName": "Kitsune" }
+```
+
+Response:
+```json
+{ "ok": true, "user": { "id": "local-user", "name": "Kitsune" }, "token": "local-dev-token" }
+```
+
+### GET /api/session
+
+```json
+{ "ok": true, "authenticated": false }
+```
+
+### POST /api/logout
+
+```json
+{ "ok": true }
+```
+
+## Notes
+
+- CORS is open (`*`) for local development.
+- No persistent session or real authentication.
+- Front-end integration is out of scope for this PBI.

--- a/server/rest-api.mjs
+++ b/server/rest-api.mjs
@@ -1,0 +1,88 @@
+import { createServer } from "node:http";
+
+const PORT = process.env.PORT ?? 8787;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+function json(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+    ...CORS_HEADERS,
+  });
+  res.end(payload);
+}
+
+async function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (chunk) => { raw += chunk; });
+    req.on("end", () => resolve(raw));
+    req.on("error", reject);
+  });
+}
+
+async function parseJSON(req) {
+  const raw = await readBody(req);
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new SyntaxError("Invalid JSON");
+  }
+}
+
+const server = createServer(async (req, res) => {
+  const { method, url } = req;
+
+  if (method === "OPTIONS") {
+    res.writeHead(204, CORS_HEADERS);
+    res.end();
+    return;
+  }
+
+  try {
+    if (method === "GET" && url === "/api/health") {
+      json(res, 200, { ok: true, service: "god-sandbox-api" });
+      return;
+    }
+
+    if (method === "POST" && url === "/api/login") {
+      const body = await parseJSON(req);
+      const name = body.playerName ?? "Guest";
+      json(res, 200, {
+        ok: true,
+        user: { id: "local-user", name },
+        token: "local-dev-token",
+      });
+      return;
+    }
+
+    if (method === "GET" && url === "/api/session") {
+      json(res, 200, { ok: true, authenticated: false });
+      return;
+    }
+
+    if (method === "POST" && url === "/api/logout") {
+      json(res, 200, { ok: true });
+      return;
+    }
+
+    json(res, 404, { ok: false, error: "Not found" });
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      json(res, 400, { ok: false, error: "Invalid JSON" });
+    } else {
+      json(res, 500, { ok: false, error: "Internal server error" });
+    }
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`god-sandbox-api listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary

- Adds `server/rest-api.mjs`: minimal REST API server using Node.js built-in `http` module (no external dependencies)
- Endpoints: `GET /api/health`, `POST /api/login`, `GET /api/session`, `POST /api/logout`
- Adds `api:dev` script to `package.json`
- Adds `server/README.md` with usage instructions
- CORS open (`*`) for local development; OPTIONS pre-flight supported
- Port via `PORT` env var, default `8787`

## Scope

- No front-end changes (`src/**` untouched)
- No new dependencies; `package-lock.json` unchanged
- No real authentication or persistent session (stub only)

## Test plan

- [ ] `npm run api:dev` → server starts, prints URL
- [ ] `curl http://localhost:8787/api/health` → `{"ok":true,"service":"god-sandbox-api"}`
- [ ] `curl -X POST http://localhost:8787/api/login -H "Content-Type: application/json" -d '{"playerName":"Kitsune"}'` → `{"ok":true,"user":{"id":"local-user","name":"Kitsune"},"token":"local-dev-token"}`
- [ ] `curl http://localhost:8787/api/session` → `{"ok":true,"authenticated":false}`
- [ ] `curl -X POST http://localhost:8787/api/logout` → `{"ok":true}`
- [ ] Unknown route returns 404
- [ ] Malformed JSON body returns 400
- [ ] `npm run build` result: pre-existing vitest type error in `world.test.ts` (exists on main, unrelated to this PR)
- [ ] `npm run test:domain` result: vitest not installed (pre-existing, unrelated to this PR)

## Notes

- `package.json` is modified (script added only) → `manual-review-required` label applied
- `package-lock.json` not changed (no dependency added)
- Front-end integration is out of scope (next PBI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)