### PR TITLE
ui: polish Ryo illustration display for PBI-002d

### DIFF
--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -307,7 +307,15 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
               <span>{eventArtGuide.portraitLine}</span>
             </div>
           </div>
-          <div className="art-slot art-slot--illustration">
+          <div
+            className={[
+              "art-slot",
+              "art-slot--illustration",
+              illustrationLoadFailed ? "" : "art-slot--with-image art-slot--illustration-image",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
             {illustrationLoadFailed ? (
               <>
                 <span className="art-slot__eyebrow">{illustrationSlot.title} / placeholder</span>

--- a/src/index.css
+++ b/src/index.css
@@ -379,6 +379,10 @@ button {
   min-height: 168px;
 }
 
+.art-slot--illustration-image {
+  min-height: 0;
+}
+
 .art-slot__image {
   display: block;
   width: 100%;
@@ -539,25 +543,56 @@ button {
 
 .modal-card {
   display: grid;
-  width: min(900px, 100%);
-  gap: 1rem;
+  width: min(980px, 100%);
+  gap: 1.25rem;
   border: 1px solid rgba(146, 175, 199, 0.18);
   border-radius: 20px;
   background: #0c1826;
   padding: 1rem;
-  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
 }
 
 .modal-card__media {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 1rem;
 }
 
 .modal-card__body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.modal-card__media .art-slot--with-image {
+  border-style: solid;
+  border-color: rgba(246, 196, 83, 0.18);
+  background: rgba(15, 25, 38, 0.94);
+}
+
+.modal-card__media .art-slot--portrait {
+  min-height: 0;
+}
+
+.modal-card__media .art-slot__image {
+  object-position: center top;
+}
+
+.modal-card__media .art-slot--portrait .art-slot__image {
+  max-height: 360px;
+}
+
+.modal-card__media .art-slot__image--illustration {
+  min-height: 0;
+  aspect-ratio: 16 / 9;
+  max-height: 210px;
+  object-position: center;
+}
+
+.modal-card__media .art-slot__meta {
+  gap: 0.4rem;
+  padding: 0.95rem;
+  line-height: 1.6;
 }
 
 .event-actions {


### PR DESCRIPTION
## Summary
- polish the EventModal media column so Ryo illustration assets display naturally after PBI-002c
- keep portrait and illustration behavior unchanged while separating loaded-image styling from placeholder fallback
- preserve the existing two-phase modal, dice reveal, and Enter confirmation flow

## Scope
PBI-002d only.

## Not included
- no ApostlePanel.tsx changes
- no artPaths.ts changes
- no asset additions or replacements
- no domain/state/app/login changes
- no backend/server/package/CI changes

## Checks
- npx tsc --noEmit
- npm run build
- npm run test:domain
- local dev check for Watch / Bless / Test illustration display, placeholder fallback path retained, no black screen, no asset load errors