### PR TITLE
backend: add Character Passport export for PBI-BE-FS-002

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test:domain": "vitest run src/domain/world.test.ts",
     "api:dev": "node server/rest-api.mjs",
-    "data:smoke": "node server/local-game-data.mjs"
+    "data:smoke": "node server/local-game-data.mjs",
+    "passport:smoke": "node server/character-passport.mjs smoke"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/server/README.md
+++ b/server/README.md
@@ -98,3 +98,65 @@ Returns `null` if the file does not exist. Throws on malformed JSON.
 ```bash
 npm run data:smoke
 ```
+
+---
+
+# god-sandbox-character-passport
+
+Character Passport v1 export module (PBI-BE-FS-002).
+
+Generates a portable JSON file representing a character from god-sandbox-mvp,
+suitable for import by other games (e.g. future tactics combat game).
+
+Uses only Node.js standard `fs/promises` — no external dependencies, no REST server.
+
+## Output location
+
+`god-sandbox-data/exports/character-passports/<characterId>.character-passport.json`
+
+## Schema: character-passport/v1
+
+```json
+{
+  "schemaVersion": "character-passport/v1",
+  "characterId": "sample-ren",
+  "name": "Ren",
+  "originGame": "god-sandbox-mvp",
+  "combatClass": "rogue",
+  "faith": {
+    "value": 50,
+    "obedienceBias": "cautious"
+  },
+  "attributes": {
+    "hp": 8,
+    "attack": 3,
+    "defense": 2,
+    "will": 4,
+    "vision": 5,
+    "stealth": 3,
+    "support": 1,
+    "chaosAffinity": 2
+  },
+  "abilities": [],
+  "history": {
+    "blessings": [],
+    "trials": [],
+    "chaosEvents": []
+  }
+}
+```
+
+Valid `combatClass` values: `vanguard`, `mage`, `rogue`, `healer`
+
+## API
+
+| Function | Description |
+|---|---|
+| `buildPassport(fields)` | Build a passport object from character fields |
+| `exportPassport(passport)` | Write passport JSON to the exports directory, returns file path |
+
+## Smoke test
+
+```bash
+npm run passport:smoke
+```

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -1,0 +1,79 @@
+import { writeFile, mkdir, readFile } from 'fs/promises';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const DATA_ROOT = resolve(process.cwd(), 'god-sandbox-data');
+const EXPORTS_DIR = join(DATA_ROOT, 'exports', 'character-passports');
+
+export function buildPassport({ characterId, name, combatClass, faith, attributes, abilities = [], history = {} }) {
+  return {
+    schemaVersion: 'character-passport/v1',
+    characterId,
+    name,
+    originGame: 'god-sandbox-mvp',
+    combatClass,
+    faith,
+    attributes,
+    abilities,
+    history: {
+      blessings: [],
+      trials: [],
+      chaosEvents: [],
+      ...history,
+    },
+  };
+}
+
+export async function exportPassport(passport) {
+  await mkdir(EXPORTS_DIR, { recursive: true });
+  const filePath = join(EXPORTS_DIR, `${passport.characterId}.character-passport.json`);
+  await writeFile(filePath, JSON.stringify(passport, null, 2) + '\n', 'utf-8');
+  return filePath;
+}
+
+const SAMPLE_REN = {
+  characterId: 'sample-ren',
+  name: 'Ren',
+  combatClass: 'rogue',
+  faith: { value: 50, obedienceBias: 'cautious' },
+  attributes: { hp: 8, attack: 3, defense: 2, will: 4, vision: 5, stealth: 3, support: 1, chaosAffinity: 2 },
+  abilities: [],
+  history: { blessings: [], trials: [], chaosEvents: [] },
+};
+
+// Smoke test — node server/character-passport.mjs smoke
+const __filename = fileURLToPath(import.meta.url);
+const isMain = Boolean(process.argv[1]) && resolve(process.argv[1]) === __filename;
+
+if (isMain && process.argv[2] === 'smoke') {
+  console.log('passport:smoke start');
+
+  const passport = buildPassport(SAMPLE_REN);
+  const outPath = await exportPassport(passport);
+  console.log('exported:', outPath);
+
+  const parsed = JSON.parse(await readFile(outPath, 'utf-8'));
+
+  if (parsed.schemaVersion !== 'character-passport/v1') {
+    console.error('FAIL: schemaVersion mismatch:', parsed.schemaVersion);
+    process.exit(1);
+  }
+  if (parsed.characterId !== 'sample-ren') {
+    console.error('FAIL: characterId mismatch:', parsed.characterId);
+    process.exit(1);
+  }
+  if (parsed.originGame !== 'god-sandbox-mvp') {
+    console.error('FAIL: originGame mismatch:', parsed.originGame);
+    process.exit(1);
+  }
+  if (!['vanguard', 'mage', 'rogue', 'healer'].includes(parsed.combatClass)) {
+    console.error('FAIL: invalid combatClass:', parsed.combatClass);
+    process.exit(1);
+  }
+
+  console.log('schema ok:', parsed.schemaVersion);
+  console.log('character ok:', parsed.name, '/', parsed.combatClass);
+  console.log('faith ok:', JSON.stringify(parsed.faith));
+  console.log('attributes ok:', Object.keys(parsed.attributes).join(', '));
+  console.log('passport:smoke OK');
+}


### PR DESCRIPTION
## Summary

- `server/character-passport.mjs`: Character Passport v1 生成モジュールを追加
- `package.json`: `passport:smoke` script を追加 (`node server/character-passport.mjs smoke`)
- `server/README.md`: Character Passport セクションを追記

## Checklist

- [x] `npm run passport:smoke` 成功 — `sample-ren.character-passport.json` 出力確認
- [x] `god-sandbox-data/exports/character-passports/` に出力
- [x] 出力 JSON が `character-passport/v1` schema に準拠
- [x] 外部 dependency 追加なし
- [x] `package-lock.json` 変更なし
- [x] `src/**` 変更なし
- [x] REST server なし (`server.listen` 不使用)
- [x] `npm run build` 成功
- [x] `npm run test:domain` 成功 (5/5)

## Test plan

- [ ] `npm run passport:smoke` を実行し `passport:smoke OK` が出ることを確認
- [ ] `god-sandbox-data/exports/character-passports/sample-ren.character-passport.json` が存在することを確認
- [ ] JSON の `schemaVersion` が `"character-passport/v1"` であることを確認
- [ ] `npm run build` が成功することを確認
- [ ] `npm run test:domain` が全テスト pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)