### PR TITLE
backend: fix local game data directory initialization for PBI-BE-FS-001

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "test:domain": "vitest run src/domain/world.test.ts",
     "api:dev": "node server/rest-api.mjs",
-    "data:smoke": "node server/local-game-data.mjs"
+    "data:smoke": "node server/local-game-data.mjs smoke"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/server/README.md
+++ b/server/README.md
@@ -77,12 +77,18 @@ god-sandbox-data/
     <saveName>.json
   sessions/
     <sessionName>.json
+  characters/
+  exports/
+    character-passports/
 ```
+
+All directories are created upfront by `initDirs()`.
 
 ## API
 
 | Function | Description |
 |---|---|
+| `initDirs()` | Create all data directories |
 | `readConfig()` | Read local config JSON |
 | `writeConfig(data)` | Write local config JSON |
 | `readSave(saveName)` | Read a named save JSON |

--- a/server/local-game-data.mjs
+++ b/server/local-game-data.mjs
@@ -1,8 +1,20 @@
-import { readFile, writeFile, mkdir, unlink } from 'fs/promises';
+import { readFile, writeFile, mkdir, unlink, access } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const DATA_ROOT = resolve(process.cwd(), 'god-sandbox-data');
+
+const DIRS = [
+  join(DATA_ROOT, 'config'),
+  join(DATA_ROOT, 'saves'),
+  join(DATA_ROOT, 'sessions'),
+  join(DATA_ROOT, 'characters'),
+  join(DATA_ROOT, 'exports', 'character-passports'),
+];
+
+export async function initDirs() {
+  await Promise.all(DIRS.map(d => mkdir(d, { recursive: true })));
+}
 
 function validateName(name) {
   if (!name || typeof name !== 'string') {
@@ -65,12 +77,19 @@ export async function writeSession(sessionName, data) {
   return writeJson(join(DATA_ROOT, 'sessions', `${sessionName}.json`), data);
 }
 
-// Smoke test — runs when invoked directly: node server/local-game-data.mjs
+// Smoke test — node server/local-game-data.mjs smoke
 const __filename = fileURLToPath(import.meta.url);
 const isMain = Boolean(process.argv[1]) && resolve(process.argv[1]) === __filename;
 
-if (isMain) {
+if (isMain && process.argv[2] === 'smoke') {
   console.log('data:smoke start');
+
+  await initDirs();
+  console.log('initDirs ok');
+
+  // Verify all directories exist
+  await Promise.all(DIRS.map(d => access(d)));
+  console.log('all dirs ok:', DIRS.map(d => d.replace(DATA_ROOT + '/', '')).join(', '));
 
   await writeConfig({ gameVersion: '0.1.0', locale: 'ja' });
   const cfg = await readConfig();


### PR DESCRIPTION
## Summary

PBI-BE-FS-001 の監査指摘事項を修正する。

- `server/local-game-data.mjs`: `initDirs()` を追加し、`characters/` と `exports/character-passports/` を含む全ディレクトリを起動時に作成する
- `server/local-game-data.mjs`: smoke test 実行条件を `process.argv[2] === 'smoke'` に変更
- `package.json`: `data:smoke` script に `smoke` 引数を追加
- `server/README.md`: `characters/` と `exports/character-passports/` をディレクトリ構造・API表に反映

この差分は orphaned commit `2f656d4` と同一内容。

## Checklist

- [x] `npm run data:smoke` 成功
- [x] `config/`, `saves/`, `sessions/`, `characters/`, `exports/character-passports/` の全ディレクトリ作成確認
- [x] `god-sandbox-data/` は git-ignored で差分に含まれない
- [x] `package-lock.json` 変更なし
- [x] `src/**` 変更なし
- [x] Character Passport 本実装なし
- [x] 外部 dependency 追加なし
- [x] `npm run build` 成功
- [x] `npm run test:domain` 成功 (5/5)

## Test plan

- [ ] `npm run data:smoke` を実行し `data:smoke OK` が出ることを確認
- [ ] `god-sandbox-data/` 配下に `characters/` と `exports/character-passports/` が作成されることを確認
- [ ] `npm run build` が成功することを確認
- [ ] `npm run test:domain` が全テスト pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)