### PR TITLE
backend: add Character Passport export for PBI-BE-FS-002

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test:domain": "vitest run src/domain/world.test.ts",
     "api:dev": "node server/rest-api.mjs",
-    "data:smoke": "node server/local-game-data.mjs smoke"
+    "data:smoke": "node server/local-game-data.mjs smoke",
+    "passport:smoke": "node server/character-passport.mjs smoke"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/server/README.md
+++ b/server/README.md
@@ -170,6 +170,11 @@ Character Passport v1 のローカル出力層です (PBI-BE-FS-002)。
 - `rogue`
 - `healer`
 
+### `characterId`
+
+`characterId` は export ファイル名に使われます。
+安全のため、空文字、`/`、`\`、`..` を含む値は拒否します。
+
 ## 出力先
 
 ```text

--- a/server/README.md
+++ b/server/README.md
@@ -104,3 +104,99 @@ Returns `null` if the file does not exist. Throws on malformed JSON.
 ```bash
 npm run data:smoke
 ```
+
+---
+
+# god-sandbox-character-passport
+
+Character Passport v1 のローカル出力層です (PBI-BE-FS-002)。
+
+箱庭で育てたキャラクターを、あとで別ゲームへ持ち出すための JSON を作ります。
+今回は **ローカルファイルへ出力するだけ** です。REST API やフロント接続は行いません。
+
+## 何ができるか
+
+- Character Passport v1 の JSON を作る
+- `god-sandbox-data/exports/character-passports/` に保存する
+- smoke コマンドで、初見の開発者でも出力結果をすぐ確認できる
+
+## 主要API
+
+| Function | Description |
+|---|---|
+| `createCharacterPassportV1(input)` | Character Passport v1 の JSON を組み立てる |
+| `writeCharacterPassportFile(passport)` | Passport JSON をローカルファイルへ保存する |
+
+## Character Passport v1 の最小仕様
+
+必須の最小項目は次のとおりです。
+
+```json
+{
+  "schemaVersion": "character-passport/v1",
+  "characterId": "sample-ren",
+  "name": "Ren",
+  "originGame": "god-sandbox-mvp",
+  "combatClass": "rogue",
+  "faith": {
+    "value": 50,
+    "obedienceBias": "cautious"
+  },
+  "attributes": {
+    "hp": 8,
+    "attack": 3,
+    "defense": 2,
+    "will": 4,
+    "vision": 5,
+    "stealth": 3,
+    "support": 1,
+    "chaosAffinity": 2
+  },
+  "abilities": [],
+  "history": {
+    "blessings": [],
+    "trials": [],
+    "chaosEvents": []
+  }
+}
+```
+
+### `combatClass`
+
+今の v1 では次の 4 種のみ許可します。
+
+- `vanguard`
+- `mage`
+- `rogue`
+- `healer`
+
+## 出力先
+
+```text
+god-sandbox-data/
+  exports/
+    character-passports/
+      sample-ren.character-passport.json
+```
+
+`writeCharacterPassportFile()` は、先に `initDirs()` を呼んで必要ディレクトリを作成してから保存します。
+
+## smoke test
+
+```bash
+npm run passport:smoke
+```
+
+これで次の 3 点を確認できます。
+
+1. Passport JSON が生成できる
+2. `god-sandbox-data/exports/character-passports/` に保存できる
+3. `schemaVersion` が `character-passport/v1` になっている
+
+## 今回まだ含まないもの
+
+- REST API
+- フロントエンドからの呼び出し
+- 認証
+- DB
+- タクティクス戦闘ゲーム本体との接続

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -8,6 +8,15 @@ const PASSPORT_DIR = join(DATA_ROOT, 'exports', 'character-passports');
 
 const VALID_CLASSES = new Set(['vanguard', 'mage', 'rogue', 'healer']);
 
+function assertSafeName(name, label) {
+  if (!name || typeof name !== 'string') {
+    throw new Error(`Invalid ${label}: must be a non-empty string.`);
+  }
+  if (name.includes('/') || name.includes('\\') || name.includes('..')) {
+    throw new Error(`Invalid ${label} "${name}": must not contain '/', '\\', or '..'.`);
+  }
+}
+
 function assertCombatClass(combatClass) {
   if (!VALID_CLASSES.has(combatClass)) {
     throw new Error(`Invalid combatClass "${combatClass}". Expected one of: ${Array.from(VALID_CLASSES).join(', ')}`);
@@ -15,6 +24,7 @@ function assertCombatClass(combatClass) {
 }
 
 export function createCharacterPassportV1(input) {
+  assertSafeName(input.characterId, 'characterId');
   assertCombatClass(input.combatClass);
 
   return {
@@ -47,6 +57,11 @@ export function createCharacterPassportV1(input) {
 }
 
 export async function writeCharacterPassportFile(passport) {
+  if (passport.schemaVersion !== 'character-passport/v1') {
+    throw new Error(`Unexpected schemaVersion: ${passport.schemaVersion}`);
+  }
+  assertSafeName(passport.characterId, 'characterId');
+
   await initDirs();
 
   const filePath = join(PASSPORT_DIR, `${passport.characterId}.character-passport.json`);
@@ -96,5 +111,22 @@ if (process.argv[2] === 'smoke') {
 
   console.log('passport file:', filePath);
   console.log('passport schema ok:', saved.schemaVersion);
+
+  try {
+    await writeCharacterPassportFile({ ...passport, characterId: '../outside' });
+    console.error('FAIL: should have rejected path traversal');
+    process.exit(1);
+  } catch (err) {
+    console.log('path traversal rejected:', err.message);
+  }
+
+  try {
+    await writeCharacterPassportFile({ ...passport, characterId: 'foo/bar' });
+    console.error('FAIL: should have rejected slash in characterId');
+    process.exit(1);
+  } catch (err) {
+    console.log('slash in characterId rejected:', err.message);
+  }
+
   console.log('passport:smoke OK');
 }

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -1,0 +1,100 @@
+import { writeFile, readFile } from 'fs/promises';
+import { join, resolve } from 'path';
+
+import { initDirs } from './local-game-data.mjs';
+
+const DATA_ROOT = resolve(process.cwd(), 'god-sandbox-data');
+const PASSPORT_DIR = join(DATA_ROOT, 'exports', 'character-passports');
+
+const VALID_CLASSES = new Set(['vanguard', 'mage', 'rogue', 'healer']);
+
+function assertCombatClass(combatClass) {
+  if (!VALID_CLASSES.has(combatClass)) {
+    throw new Error(`Invalid combatClass "${combatClass}". Expected one of: ${Array.from(VALID_CLASSES).join(', ')}`);
+  }
+}
+
+export function createCharacterPassportV1(input) {
+  assertCombatClass(input.combatClass);
+
+  return {
+    schemaVersion: 'character-passport/v1',
+    characterId: input.characterId,
+    name: input.name,
+    originGame: 'god-sandbox-mvp',
+    combatClass: input.combatClass,
+    faith: {
+      value: input.faith.value,
+      obedienceBias: input.faith.obedienceBias,
+    },
+    attributes: {
+      hp: input.attributes.hp,
+      attack: input.attributes.attack,
+      defense: input.attributes.defense,
+      will: input.attributes.will,
+      vision: input.attributes.vision,
+      stealth: input.attributes.stealth,
+      support: input.attributes.support,
+      chaosAffinity: input.attributes.chaosAffinity,
+    },
+    abilities: [...input.abilities],
+    history: {
+      blessings: [...input.history.blessings],
+      trials: [...input.history.trials],
+      chaosEvents: [...input.history.chaosEvents],
+    },
+  };
+}
+
+export async function writeCharacterPassportFile(passport) {
+  await initDirs();
+
+  const filePath = join(PASSPORT_DIR, `${passport.characterId}.character-passport.json`);
+  await writeFile(filePath, JSON.stringify(passport, null, 2) + '\n', 'utf-8');
+
+  return filePath;
+}
+
+function sampleRenPassport() {
+  return createCharacterPassportV1({
+    characterId: 'sample-ren',
+    name: 'Ren',
+    combatClass: 'rogue',
+    faith: {
+      value: 50,
+      obedienceBias: 'cautious',
+    },
+    attributes: {
+      hp: 8,
+      attack: 3,
+      defense: 2,
+      will: 4,
+      vision: 5,
+      stealth: 3,
+      support: 1,
+      chaosAffinity: 2,
+    },
+    abilities: [],
+    history: {
+      blessings: [],
+      trials: [],
+      chaosEvents: [],
+    },
+  });
+}
+
+if (process.argv[2] === 'smoke') {
+  console.log('passport:smoke start');
+
+  const passport = sampleRenPassport();
+  const filePath = await writeCharacterPassportFile(passport);
+  const saved = JSON.parse(await readFile(filePath, 'utf-8'));
+
+  if (saved.schemaVersion !== 'character-passport/v1') {
+    throw new Error(`Unexpected schemaVersion: ${saved.schemaVersion}`);
+  }
+
+  console.log('passport file:', filePath);
+  console.log('passport schema ok:', saved.schemaVersion);
+  console.log('passport:smoke OK');
+}


### PR DESCRIPTION
## Summary
- add server/character-passport.mjs for Character Passport v1 local export
- add passport:smoke to generate a sample Character Passport JSON locally
- document the export interface and v1 schema in server/README.md

## Scope
PBI-BE-FS-002 only.

## Not included
- no REST API changes
- no frontend changes
- no backend dependency additions
- no package-lock.json changes
- no Character Passport gameplay integration

## Checks
- 
pm run passport:smoke
- 
pm run build
- 
pm run test:domain