### PR TITLE
docs: localize design documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ﻿# god-sandbox-mvp
 
-Private MVP repository for a god-sandbox prototype managed with Codex.
+Codex と一緒に開発している、神視点箱庭プロトタイプの非公開 MVP リポジトリです。
 
-Bot routine PR smoke test 4.
+自動作業 PR の smoke test 記録: 4。
 
 ---
 
@@ -54,15 +54,15 @@ chmod +x start.sh
 
 ---
 
-## Getting Started (for developers)
+## 開発者向けセットアップ
 
-### Requirements
+### 必要なもの
 
 - **Node.js 22.x** — [nodejs.org](https://nodejs.org/)
-- **npm** (bundled with Node.js)
+- **npm** (Node.js に同梱)
 - **Git**
 
-### Setup
+### セットアップ
 
 ```bash
 git clone https://github.com/KitsuneSavaskiy/god-sandbox-mvp.git
@@ -70,22 +70,22 @@ cd god-sandbox-mvp
 npm ci
 ```
 
-### Run frontend
+### フロントエンド起動
 
 ```bash
 npm run dev
 ```
 
-Open `http://localhost:5173/` in your browser.
+ブラウザで `http://localhost:5173/` を開いてください。
 
-### Basic flow
+### 基本の流れ
 
-1. Login screen appears — enter any name to proceed.
-2. The sandbox world loads and ticks automatically.
-3. Events fire periodically; an EventModal pops up with choices.
-4. Select a choice to apply world intervention and continue.
+1. ログイン画面が表示されます。任意の名前を入力すると進めます。
+2. 箱庭世界が読み込まれ、tick が自動で進みます。
+3. 条件を満たすと EventModal が開き、介入の選択肢が表示されます。
+4. 選択肢を選ぶと世界への介入が適用され、進行が続きます。
 
-### Checks
+### 確認コマンド
 
 ```bash
 npm run typecheck    # TypeScript type check
@@ -93,27 +93,27 @@ npm run test:domain  # Domain unit tests
 npm run build        # Production build
 ```
 
-### Troubleshooting
+### トラブルシュート
 
-| Problem | Solution |
+| 問題 | 対応 |
 |---|---|
-| `npm run dev` fails to start | Make sure Node.js 22.x is installed and `npm ci` completed successfully. |
-| Black screen after launch | Open DevTools Console (F12) and check for errors. |
-| Port 5173 already in use | Stop the other process using port 5173, or run `npm run dev -- --port 5174` to use a different port. |
+| `npm run dev` が起動しない | Node.js 22.x が入っていることと、`npm ci` が成功していることを確認してください。 |
+| 起動後に黒画面になる | DevTools Console (F12) を開き、runtime error が出ていないか確認してください。 |
+| Port 5173 が使用中 | 5173 番を使っている別プロセスを止めるか、`npm run dev -- --port 5174` で別ポートを使ってください。 |
 
 ---
 
-### Optional: local REST API
+### 任意: ローカル REST API
 
-Start the local API server in a separate terminal:
+別ターミナルでローカル API サーバーを起動します。
 
 ```bash
 npm run api:dev
 ```
 
-The server listens on `http://localhost:8787`.
+サーバーは `http://localhost:8787` で待ち受けます。
 
-Health check:
+疎通確認:
 
 ```bash
 curl http://localhost:8787/api/health

--- a/docs/tactics-five-phases-glossary.md
+++ b/docs/tactics-five-phases-glossary.md
@@ -1,16 +1,19 @@
-# Five Phases Tactics Glossary
+# 五行タクティクス用語辞書
 
-This document fixes the vocabulary for Character Passport v1 and a future Five Phases tactics game.
+この資料は、Character Passport v1 と将来の五行ベースのタクティクス戦闘ゲームに向けて、用語の意味を固定するための辞書です。
 
-It is a design glossary, not an implementation. No runtime behavior, battle formula, API, or persistence rule is defined here.
+これは設計辞書であり、実装ではありません。実行時挙動、戦闘式、API、永続化ルールはここでは定義しません。
 
-## Purpose
+## この資料の目的
 
-- Give developers one shared interpretation of Five Phases tactics terms.
-- Keep Character Passport v1 fields readable before battle code exists.
-- Separate glossary decisions from future implementation details.
+- 五行タクティクス用語の解釈を開発者間で揃える。
+- 戦闘コードが存在する前に、Character Passport v1 の各項目を読める状態にする。
+- 用語の決定と、将来の実装詳細を分離する。
 
-## Five Phases And Classes
+## 五行と職種
+
+この資料では、木（wood）、火（fire）、土（earth）、金（metal）、水（water）を五行（element）として扱います。
+MVP では、職種（combatClass）と五行は 1:1 で対応します。
 
 ```text
 wood  = ranger
@@ -20,14 +23,14 @@ metal = knight
 water = healer
 ```
 
-MVP rule:
+MVP でのルール:
 
 ```text
 MVPでは element と combatClass は 1:1 固定。
 将来は分離可能だが、v1では分離しない。
 ```
 
-## Five Phases Core Roles
+## 五行の代表機能
 
 ```text
 wood:
@@ -46,7 +49,7 @@ water:
 根源・回復・継承
 ```
 
-## Combat Classes
+## 職種定義
 
 ```text
 Ranger:
@@ -59,13 +62,13 @@ Guardian:
 土。防御、陣地、補給、安定を担う。
 
 Knight:
-金。突撃前衛ではなく、境界を守り、規律で行動を制限する boundary controller。
+金。突撃前衛ではなく、境界を守り、規律で行動を制限する境界制御役。
 
 Healer:
 水。単なるHP回復役ではなく、浄化、復元、位置調整、継承を担う。
 ```
 
-## Attributes
+## 基本ステータス
 
 ```text
 Vision:
@@ -85,7 +88,7 @@ Flow:
 回避まではMVPでは含めない。
 ```
 
-## Status Conditions And Debuffs
+## 状態異常とデバフの区別
 
 ```text
 Status condition:
@@ -95,7 +98,7 @@ Debuff:
 数値・盤面性能・命中・防御などを下げる性能低下。
 ```
 
-Representative examples:
+代表例:
 
 ```text
 Rooted:
@@ -105,7 +108,7 @@ Entangled:
 デバフ。視界、経路、罠回避などの盤面対応力を下げる。
 ```
 
-## Status Conditions
+## 状態異常
 
 ```text
 wood  = Rooted
@@ -115,10 +118,10 @@ metal = Sealed
 water = Chilled
 ```
 
-`Chilled` is the water status condition. Its primary effect is **action order reduction**.
-If firepower reduction or movement reduction is added later, treat it as a secondary effect.
+`Chilled` は水の状態異常です。主効果は **行動順低下** に固定します。
+火力低下や移動低下を後から入れる場合は、副効果として扱います。
 
-## Buffs
+## バフ
 
 ```text
 wood  = Growth
@@ -128,7 +131,7 @@ metal = Focus
 water = Flowing
 ```
 
-## Debuffs
+## デバフ
 
 ```text
 wood  = Entangled
@@ -138,10 +141,10 @@ metal = Fractured
 water = Displaced
 ```
 
-`Displaced` has **position drift / positional disadvantage** as its primary effect.
-Do not mix it with accuracy reduction or action order reduction.
+`Displaced` は **位置ずれ・配置不利** を主効果にします。
+命中低下や行動順低下とは混ぜません。
 
-## statusAffinity
+## 状態異常適性（statusAffinity）
 
 ```text
 statusAffinity は、状態異常の「付与されやすさ / 抵抗しやすさ」を表す。
@@ -156,7 +159,7 @@ statusAffinity は、状態異常の「付与されやすさ / 抵抗しやす�
 +2 = とても抵抗しやすい
 ```
 
-## Faith
+## 信仰度（Faith）
 
 ```text
 Faith は五行とは別軸。
@@ -165,7 +168,7 @@ Faith は五行とは別軸。
 命令解釈、危険命令への反応、自律判断とのせめぎ合いを含む。
 ```
 
-Faith value:
+信仰度の値（Faith value）:
 
 ```text
 0-20:
@@ -184,7 +187,7 @@ Faith value:
 強く信頼し、危険な命令にも従いやすい
 ```
 
-obedienceBias:
+服従傾向（obedienceBias）:
 
 ```text
 cautious:
@@ -203,7 +206,7 @@ adaptive:
 状況に合わせて柔軟に従う
 ```
 
-Faith.source:
+信仰度の由来（Faith.source）:
 
 ```text
 blessings:
@@ -216,12 +219,12 @@ chaosExposure:
 カオス兆候や不安定な世界状況に晒された履歴量
 ```
 
-## Generating And Overcoming
+## 相生 / 相剋
 
-No numeric multiplier is defined yet.
-For MVP, define only effect categories.
+数値倍率はまだ決めません。
+MVP では効果カテゴリだけを定義します。
 
-Generating cycle:
+相生:
 
 ```text
 wood -> fire:
@@ -240,7 +243,7 @@ water -> wood:
 Healer の浄化・復元で Ranger の視野・機動が伸びる
 ```
 
-Overcoming cycle:
+相剋:
 
 ```text
 wood -> earth:
@@ -259,7 +262,7 @@ metal -> wood:
 Knight が Ranger の拘束・罠・蔦を切断する
 ```
 
-## Attack Pattern Policy
+## attack pattern 方針
 
 ```text
 技は以下で制御する:
@@ -269,7 +272,7 @@ Knight が Ranger の拘束・罠・蔦を切断する
 - secondary effect
 ```
 
-Five Phases range tendencies:
+五行ごとの範囲傾向:
 
 ```text
 wood:
@@ -288,7 +291,7 @@ water:
 位置操作、押し流し、全体弱効果、指定位置操作
 ```
 
-## Canonical Keys
+## canonical key 一覧
 
 ```text
 elements:

--- a/docs/tactics-growth-and-abilities-glossary.md
+++ b/docs/tactics-growth-and-abilities-glossary.md
@@ -1,16 +1,16 @@
-# Growth And Abilities Glossary
+# 成長と特殊能力の用語辞書
 
-This document fixes the vocabulary for Blessing, Trial, Chaos, growth, and abilities before Character Passport v1 grows beyond its current minimal schema.
+この資料は、Character Passport v1 が現在の最小スキーマから拡張される前に、加護（Blessing）、試練（Trial）、カオス（Chaos）、成長（growth）、特殊能力（abilities）の意味を固定するための用語辞書です。
 
-It is a design glossary, not an implementation. It does not define formulas, runtime behavior, REST APIs, or frontend UI.
+これは設計辞書であり、実装ではありません。数式、実行時挙動、REST API、フロントエンド UI は定義しません。
 
-## Purpose
+## この資料の目的
 
-- Treat Blessing, Trial, and Chaos as sources of growth, resistance, and special abilities, not only as Faith inputs.
-- Fix the meaning of `growth` and `abilities` before Character Passport v1 implementation expands.
-- Give future tactics-game developers a shared language for interpreting character export data.
+- 加護 / 試練 / カオスを、信仰度（Faith）だけでなく、成長・耐性・特殊能力の源泉として扱う。
+- Character Passport v1 の実装が拡張される前に、`growth` と `abilities` の意味を固定する。
+- 将来のタクティクスゲーム開発者が、キャラクター export データを同じ意味で読めるようにする。
 
-## Blessing / Trial / Chaos
+## 加護 / 試練 / カオス
 
 ```text
 Blessing:
@@ -26,14 +26,14 @@ Chaos:
 尖った成長、例外能力、Faith解釈の揺らぎの源泉。
 ```
 
-## Relationship To Faith
+## 信仰度（Faith）との関係
 
 ```text
-Blessing / Trial / Chaos は Faith に影響するが、Faith だけの材料ではない。
-影響先は growth category ごとに異なる。
+加護 / 試練 / カオスは信仰度（Faith）に影響するが、Faith だけの材料ではない。
+影響先は成長カテゴリ（growth category）ごとに異なる。
 ```
 
-## growth Structure
+## 成長（growth）構造案
 
 ```json
 {
@@ -63,7 +63,7 @@ Blessing / Trial / Chaos は Faith に影響するが、Faith だけの材料で
 }
 ```
 
-## Growth Influence Targets
+## 成長要素の影響先
 
 ```text
 Blessing:
@@ -88,7 +88,7 @@ Chaos:
 - 意味: 不安定な変質・例外能力
 ```
 
-## Ability Categories
+## 特殊能力の分類
 
 ```text
 Class Ability:
@@ -104,10 +104,10 @@ Chaos Ability:
 カオス由来の不安定・例外的能力。
 ```
 
-JSON keys:
+JSON key 対応:
 
 ```text
-Human label -> JSON key
+人間向けラベル -> JSON key
 
 Class Ability -> class
 Blessing Ability -> blessing
@@ -115,7 +115,7 @@ Trial Ability -> trial
 Chaos Ability -> chaos
 ```
 
-## Skill And Ability
+## 技（Skill）と特殊能力（Ability）の境界
 
 ```text
 Skill:
@@ -127,14 +127,14 @@ Ability:
 例: 被弾時に発動、状態異常時に発動、周囲に常時効果。
 ```
 
-Character Passport storage rule:
+Character Passport での保存先:
 
 ```text
 Character Passport v1 では、能動行動は `skills` に保存する。
 条件発動・常時効果・反応効果は `abilities` に保存する。
 ```
 
-## ability Schema Draft
+## ability schema 案
 
 ```json
 {
@@ -159,7 +159,7 @@ Character Passport v1 では、能動行動は `skills` に保存する。
 }
 ```
 
-## Canonical Keys
+## canonical key 一覧
 
 ```text
 growthCategories:
@@ -181,15 +181,15 @@ effectTypes:
 buff, debuff, statusCondition, heal, damage, move, cleanse, summon, modifyFaith
 ```
 
-## Character Passport Reflection
+## Character Passport への反映方針
 
 ```text
-Character Passport v1 should keep:
-- skills: active actions
-- abilities: passive / reaction / aura effects
+Character Passport v1 は次の保存先を維持する:
+- skills: 能動行動
+- abilities: passive / reaction / aura 効果
 ```
 
-## Not Decided Yet
+## 今回まだ決めないもの
 
 - 数式
 - Faith の増減量

--- a/server/README.md
+++ b/server/README.md
@@ -1,10 +1,10 @@
 # god-sandbox-api
 
-Local REST API skeleton for development use (PBI-BE-API-001).
+開発用のローカル REST API ひな形です (PBI-BE-API-001)。
 
-Built with Node.js standard `http` module — no external dependencies.
+Node.js 標準の `http` モジュールだけで作られており、外部依存はありません。
 
-## Start
+## 起動
 
 ```bash
 npm run api:dev
@@ -12,14 +12,14 @@ npm run api:dev
 PORT=8787 node server/rest-api.mjs
 ```
 
-## Endpoints
+## エンドポイント
 
-| Method | Path           | Description              |
+| Method | Path           | 説明                     |
 |--------|----------------|--------------------------|
-| GET    | /api/health    | Server liveness check    |
-| POST   | /api/login     | Stub login               |
-| GET    | /api/session   | Stub session check       |
-| POST   | /api/logout    | Stub logout              |
+| GET    | /api/health    | サーバーの疎通確認       |
+| POST   | /api/login     | 仮ログイン               |
+| GET    | /api/session   | 仮セッション確認         |
+| POST   | /api/logout    | 仮ログアウト             |
 
 ### GET /api/health
 
@@ -29,12 +29,12 @@ PORT=8787 node server/rest-api.mjs
 
 ### POST /api/login
 
-Request body:
+リクエスト body:
 ```json
 { "playerName": "Kitsune" }
 ```
 
-Response:
+レスポンス:
 ```json
 { "ok": true, "user": { "id": "local-user", "name": "Kitsune" }, "token": "local-dev-token" }
 ```
@@ -51,23 +51,23 @@ Response:
 { "ok": true }
 ```
 
-## Notes
+## 注意点
 
-- CORS is open (`*`) for local development.
-- No persistent session or real authentication.
-- Front-end integration is out of scope for this PBI.
+- ローカル開発用に CORS は `*` で開いています。
+- 永続セッションや実認証はまだありません。
+- フロントエンド接続はこの PBI の範囲外です。
 
 ---
 
 # god-sandbox-local-game-data
 
-Local file storage layer for game data (PBI-BE-FS-001).
+ゲームデータ用のローカルファイル保存層です (PBI-BE-FS-001)。
 
-Uses only Node.js standard `fs/promises` and `path` — no external dependencies, no REST server.
+Node.js 標準の `fs/promises` と `path` だけを使います。外部依存や REST サーバーはありません。
 
-## Data root
+## データルート
 
-`god-sandbox-data/` is created in the working directory at runtime and is git-ignored.
+`god-sandbox-data/` は実行時に作業ディレクトリ直下へ作られます。このディレクトリは git 管理対象外です。
 
 ```text
 god-sandbox-data/
@@ -82,24 +82,24 @@ god-sandbox-data/
     character-passports/
 ```
 
-All directories are created upfront by `initDirs()`.
+必要なディレクトリは `initDirs()` によって先に作成されます。
 
 ## API
 
-| Function | Description |
+| 関数 | 説明 |
 |---|---|
-| `initDirs()` | Create all data directories |
-| `readConfig()` | Read local config JSON |
-| `writeConfig(data)` | Write local config JSON |
-| `readSave(saveName)` | Read a named save JSON |
-| `writeSave(saveName, data)` | Write a named save JSON |
-| `readSession(sessionName)` | Read a named session JSON |
-| `writeSession(sessionName, data)` | Write a named session JSON |
+| `initDirs()` | 必要なデータディレクトリを作成する |
+| `readConfig()` | ローカル設定 JSON を読む |
+| `writeConfig(data)` | ローカル設定 JSON を書く |
+| `readSave(saveName)` | 指定名の save JSON を読む |
+| `writeSave(saveName, data)` | 指定名の save JSON を書く |
+| `readSession(sessionName)` | 指定名の session JSON を読む |
+| `writeSession(sessionName, data)` | 指定名の session JSON を書く |
 
-Returns `null` if the file does not exist. Throws on malformed JSON.
-`saveName` / `sessionName` must not contain `/`, `\`, or `..`.
+ファイルが存在しない場合は `null` を返します。壊れた JSON は例外にします。
+`saveName` / `sessionName` には `/`、`\`、`..` を含めてはいけません。
 
-## Smoke test
+## smoke test
 
 ```bash
 npm run data:smoke
@@ -122,7 +122,7 @@ Character Passport v1 のローカル出力層です (PBI-BE-FS-002)。
 
 ## 主要API
 
-| Function | Description |
+| 関数 | 説明 |
 |---|---|
 | `createCharacterPassportV1(input)` | Character Passport v1 の JSON を組み立てる |
 | `writeCharacterPassportFile(passport)` | Passport JSON をローカルファイルへ保存する |


### PR DESCRIPTION
## Summary
- Localize human-facing README / server README text to Japanese
- Localize human-facing descriptions in the Five Phases and Growth / Abilities glossaries
- Keep JSON keys, canonical keys, npm scripts, file paths, commands, API paths, enum values, schemaVersion, and implementation examples in English

## Scope
Follow-up for PBI-TACTICS-DESIGN-002-FIX documentation wording rules.

## Not included
- No code changes
- No package changes
- No CI changes
- No schema or runtime behavior changes

## Checks
- git diff --check