### PR TITLE
LLM発話 provider adapter skeleton を追加する

### DIFF
--- a/src/application/utterance/types.ts
+++ b/src/application/utterance/types.ts
@@ -1,0 +1,70 @@
+export type UtteranceProviderKind = "mock" | "template" | "serverProxy";
+
+export type UtteranceLanguage = "ja" | "en";
+
+export type UtteranceGenerationMode = "safe" | "dramatic" | "quiet";
+
+export type UtteranceEventKind =
+  | "watch"
+  | "bless"
+  | "test"
+  | "warning"
+  | "routine"
+  | "manual"
+  | "unknown";
+
+export interface UtteranceCharacterContext {
+  id: string;
+  name: string;
+  personalitySummary?: string;
+  faithSummary?: string;
+  growthSummary?: string;
+  statusSummary?: string;
+}
+
+export interface UtteranceSituationContext {
+  eventKind: UtteranceEventKind;
+  eventSummary?: string;
+  chaosSummary?: string;
+  worldSummary?: string;
+}
+
+export interface UtteranceConstraints {
+  maxLength: number;
+  language: UtteranceLanguage;
+  mode: UtteranceGenerationMode;
+}
+
+export interface UtteranceRequest {
+  requestId: string;
+  character: UtteranceCharacterContext;
+  situation: UtteranceSituationContext;
+  constraints: UtteranceConstraints;
+}
+
+export type UtteranceResponseStatus = "ok" | "unavailable" | "no-utterance";
+
+export interface UtteranceResponse {
+  status: UtteranceResponseStatus;
+  providerKind: UtteranceProviderKind;
+  text: string | null;
+  reason?: string;
+}
+
+export interface LlmProvider {
+  kind: UtteranceProviderKind;
+  generate(request: UtteranceRequest): Promise<UtteranceResponse>;
+}
+
+export interface LlmProviderConfig {
+  providerKind: UtteranceProviderKind;
+  modelPreference?: string;
+  maxOutputLength: number;
+  language: UtteranceLanguage;
+  generationMode: UtteranceGenerationMode;
+}
+
+export interface LlmProviderConfigRepository {
+  readConfig(): Promise<LlmProviderConfig>;
+  writeConfig(config: LlmProviderConfig): Promise<void>;
+}

--- a/src/infrastructure/config/nonSecretLlmProviderConfigRepository.ts
+++ b/src/infrastructure/config/nonSecretLlmProviderConfigRepository.ts
@@ -1,0 +1,57 @@
+import type {
+  LlmProviderConfig,
+  LlmProviderConfigRepository,
+} from "../../application/utterance/types";
+
+const SECRET_FIELD_NAMES = new Set([
+  "apiKey",
+  "api_key",
+  "authorization",
+  "password",
+  "refreshToken",
+  "refresh_token",
+  "secret",
+  "token",
+  "userSecret",
+  "user_secret",
+]);
+
+function assertNoSecretFields(value: unknown, path = "config") {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoSecretFields(entry, `${path}[${index}]`));
+    return;
+  }
+
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (SECRET_FIELD_NAMES.has(key)) {
+      throw new Error(`${path}.${key} must not be stored in non-secret provider config.`);
+    }
+
+    assertNoSecretFields(entry, `${path}.${key}`);
+  }
+}
+
+export function assertNonSecretLlmProviderConfig(config: LlmProviderConfig) {
+  assertNoSecretFields(config);
+}
+
+export function createNonSecretLlmProviderConfigRepository(
+  initialConfig: LlmProviderConfig,
+): LlmProviderConfigRepository {
+  assertNonSecretLlmProviderConfig(initialConfig);
+  let currentConfig = { ...initialConfig };
+
+  return {
+    async readConfig() {
+      return { ...currentConfig };
+    },
+    async writeConfig(config) {
+      assertNonSecretLlmProviderConfig(config);
+      currentConfig = { ...config };
+    },
+  };
+}

--- a/src/infrastructure/llm/mockProvider.ts
+++ b/src/infrastructure/llm/mockProvider.ts
@@ -1,0 +1,27 @@
+import type { LlmProvider, UtteranceRequest, UtteranceResponse } from "../../application/utterance/types";
+
+function clampText(text: string, maxLength: number) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return text.slice(0, Math.max(0, maxLength - 1)) + "…";
+}
+
+export function createMockProvider(): LlmProvider {
+  return {
+    kind: "mock",
+    async generate(request: UtteranceRequest): Promise<UtteranceResponse> {
+      const text =
+        request.constraints.language === "ja"
+          ? `${request.character.name}は静かに状況を見つめている。`
+          : `${request.character.name} quietly watches the situation.`;
+
+      return {
+        status: "ok",
+        providerKind: "mock",
+        text: clampText(text, request.constraints.maxLength),
+      };
+    },
+  };
+}

--- a/src/infrastructure/llm/serializers/serverProxySerializer.ts
+++ b/src/infrastructure/llm/serializers/serverProxySerializer.ts
@@ -1,0 +1,26 @@
+import type { UtteranceRequest } from "../../../application/utterance/types";
+
+export interface ServerProxySerializationOptions {
+  proxyName: string;
+}
+
+export interface ServerProxyUtterancePayload {
+  proxyName: string;
+  requestId: string;
+  character: UtteranceRequest["character"];
+  situation: UtteranceRequest["situation"];
+  constraints: UtteranceRequest["constraints"];
+}
+
+export function serializeForServerProxy(
+  request: UtteranceRequest,
+  options: ServerProxySerializationOptions,
+): ServerProxyUtterancePayload {
+  return {
+    proxyName: options.proxyName,
+    requestId: request.requestId,
+    character: request.character,
+    situation: request.situation,
+    constraints: request.constraints,
+  };
+}

--- a/src/infrastructure/llm/serverProxyProvider.ts
+++ b/src/infrastructure/llm/serverProxyProvider.ts
@@ -1,0 +1,29 @@
+import type { LlmProvider, UtteranceRequest, UtteranceResponse } from "../../application/utterance/types";
+import { serializeForServerProxy } from "./serializers/serverProxySerializer";
+
+export interface ServerProxyProviderOptions {
+  proxyName?: string;
+  endpointPath?: string;
+}
+
+export function createServerProxyProvider(options: ServerProxyProviderOptions = {}): LlmProvider {
+  return {
+    kind: "serverProxy",
+    async generate(request: UtteranceRequest): Promise<UtteranceResponse> {
+      const payload = serializeForServerProxy(request, {
+        proxyName: options.proxyName ?? "default-server-proxy",
+      });
+
+      void payload;
+
+      return {
+        status: "unavailable",
+        providerKind: "serverProxy",
+        text: null,
+        reason: options.endpointPath
+          ? "serverProxyProvider transport is not implemented in this PBI."
+          : "serverProxyProvider is not configured.",
+      };
+    },
+  };
+}

--- a/src/infrastructure/llm/templateProvider.ts
+++ b/src/infrastructure/llm/templateProvider.ts
@@ -1,0 +1,56 @@
+import type {
+  LlmProvider,
+  UtteranceEventKind,
+  UtteranceRequest,
+  UtteranceResponse,
+} from "../../application/utterance/types";
+
+const JAPANESE_TEMPLATES: Record<UtteranceEventKind, string> = {
+  watch: "{name}は、見届けられたことに気づいて息を整えた。",
+  bless: "{name}は、かすかな加護の気配に目を細めた。",
+  test: "{name}は、試練の気配を前にして拳を握った。",
+  warning: "{name}は、迫る終わりの気配に言葉を失った。",
+  routine: "{name}は、流れる日々の中で小さくうなずいた。",
+  manual: "{name}は、神の気配を感じて顔を上げた。",
+  unknown: "{name}は、世界の揺らぎを静かに受け止めた。",
+};
+
+const ENGLISH_TEMPLATES: Record<UtteranceEventKind, string> = {
+  watch: "{name} notices that someone has been watching over them.",
+  bless: "{name} narrows their eyes at a faint blessing.",
+  test: "{name} clenches a fist before the coming trial.",
+  warning: "{name} falls silent before the approaching end.",
+  routine: "{name} nods quietly amid ordinary days.",
+  manual: "{name} looks up as a divine presence draws near.",
+  unknown: "{name} quietly receives the world's distortion.",
+};
+
+function renderTemplate(template: string, name: string) {
+  return template.replaceAll("{name}", name);
+}
+
+function clampText(text: string, maxLength: number) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return text.slice(0, Math.max(0, maxLength - 1)) + "…";
+}
+
+export function createTemplateProvider(): LlmProvider {
+  return {
+    kind: "template",
+    async generate(request: UtteranceRequest): Promise<UtteranceResponse> {
+      const templates =
+        request.constraints.language === "ja" ? JAPANESE_TEMPLATES : ENGLISH_TEMPLATES;
+      const template = templates[request.situation.eventKind] ?? templates.unknown;
+      const text = renderTemplate(template, request.character.name);
+
+      return {
+        status: "ok",
+        providerKind: "template",
+        text: clampText(text, request.constraints.maxLength),
+      };
+    },
+  };
+}

--- a/src/infrastructure/llm/utteranceProviders.test.ts
+++ b/src/infrastructure/llm/utteranceProviders.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { LlmProviderConfig, UtteranceRequest } from "../../application/utterance/types";
+import { createNonSecretLlmProviderConfigRepository } from "../config/nonSecretLlmProviderConfigRepository";
+import { createMockProvider } from "./mockProvider";
+import { createServerProxyProvider } from "./serverProxyProvider";
+import { serializeForServerProxy } from "./serializers/serverProxySerializer";
+import { createTemplateProvider } from "./templateProvider";
+
+const baseRequest: UtteranceRequest = {
+  requestId: "test-request",
+  character: {
+    id: "ryo",
+    name: "Ryo",
+    faithSummary: "神の声を慎重に受け止める。",
+  },
+  situation: {
+    eventKind: "test",
+    eventSummary: "試練が近づいている。",
+  },
+  constraints: {
+    maxLength: 80,
+    language: "ja",
+    mode: "safe",
+  },
+};
+
+describe("utterance provider skeletons", () => {
+  it("mockProvider returns deterministic text without external calls", async () => {
+    const provider = createMockProvider();
+
+    await expect(provider.generate(baseRequest)).resolves.toEqual({
+      status: "ok",
+      providerKind: "mock",
+      text: "Ryoは静かに状況を見つめている。",
+    });
+  });
+
+  it("templateProvider renders event-specific template text", async () => {
+    const provider = createTemplateProvider();
+    const response = await provider.generate(baseRequest);
+
+    expect(response.status).toBe("ok");
+    expect(response.providerKind).toBe("template");
+    expect(response.text).toBe("Ryoは、試練の気配を前にして拳を握った。");
+  });
+
+  it("serverProxyProvider stays unavailable until transport is implemented", async () => {
+    const provider = createServerProxyProvider();
+    const response = await provider.generate(baseRequest);
+
+    expect(response).toEqual({
+      status: "unavailable",
+      providerKind: "serverProxy",
+      text: null,
+      reason: "serverProxyProvider is not configured.",
+    });
+  });
+
+  it("serializes only provider-neutral request data for server proxy", () => {
+    const payload = serializeForServerProxy(baseRequest, { proxyName: "local-proxy" });
+
+    expect(payload).toEqual({
+      proxyName: "local-proxy",
+      requestId: baseRequest.requestId,
+      character: baseRequest.character,
+      situation: baseRequest.situation,
+      constraints: baseRequest.constraints,
+    });
+    expect(JSON.stringify(payload)).not.toContain("apiKey");
+    expect(JSON.stringify(payload)).not.toContain("userSecret");
+  });
+
+  it("non-secret config repository rejects secret-like fields", async () => {
+    const initialConfig: LlmProviderConfig = {
+      providerKind: "mock",
+      maxOutputLength: 80,
+      language: "ja",
+      generationMode: "safe",
+    };
+    const repository = createNonSecretLlmProviderConfigRepository(initialConfig);
+
+    await expect(repository.readConfig()).resolves.toEqual(initialConfig);
+    await expect(
+      repository.writeConfig({
+        ...initialConfig,
+        apiKey: "must-not-be-stored",
+      } as LlmProviderConfig),
+    ).rejects.toThrow("apiKey must not be stored");
+  });
+});


### PR DESCRIPTION
## 概要

- `src/application/utterance/**` に provider-neutral な `LlmProvider` port と `UtteranceRequest` / `UtteranceResponse` / config repository port を追加
- `src/infrastructure/llm/**` に `mockProvider` / `templateProvider` / `serverProxyProvider` の skeleton を追加
- provider-specific serializer の置き場所として `serializers/serverProxySerializer.ts` を追加
- `src/infrastructure/config/**` に secret を保存しない config repository skeleton を追加
- 実LLM接続、HTTP通信、API key保存、UI接続は行っていません

## 変更ファイル一覧

- `src/application/utterance/types.ts`
- `src/infrastructure/config/nonSecretLlmProviderConfigRepository.ts`
- `src/infrastructure/llm/mockProvider.ts`
- `src/infrastructure/llm/templateProvider.ts`
- `src/infrastructure/llm/serverProxyProvider.ts`
- `src/infrastructure/llm/serializers/serverProxySerializer.ts`
- `src/infrastructure/llm/utteranceProviders.test.ts`

## レーン独立性

レーンBの担当範囲である `src/application/utterance/**` と `src/infrastructure/**` のみに閉じています。
レーンA担当の `src/domain/**`、`src/application/passport/**`、`src/application/tactics/**` には触れていません。
`src/presentation/**`、`server/**`、`package.json`、CI workflow も変更していません。

## 今回やらないこと

- OpenAI / Anthropic API接続
- fetch / HTTP通信の本実装
- API key保存
- secure storage実装
- mobile対応実装
- provider設定UI
- 発話履歴保存
- moderation実装
- Character Passport統合
- frontend UI変更
- server/** の変更
- package変更
- CI変更

## 確認

- `npx vitest run src/infrastructure/llm/utteranceProviders.test.ts`
- `npm run test:domain`
- `npm run build`

補足: `npm run build` は既存の chunk size warning を出しますが、build 自体は成功しています。