### PR TITLE
Character Passport / tactics のDomain境界を定義

### DIFF
--- a/src/application/passport/generateCharacterPassport.ts
+++ b/src/application/passport/generateCharacterPassport.ts
@@ -1,0 +1,31 @@
+import type { CharacterPassportV1 } from "../../domain/passport/characterPassport";
+import type { FaithDraft } from "../../domain/passport/faith";
+import type { CharacterGrowth } from "../../domain/passport/growth";
+import type { AbilityDefinition, SkillDefinition } from "../../domain/passport/skill";
+import type { BasicAttributeSet, CombatClass, FivePhaseElement } from "../../domain/passport/fivePhases";
+
+export interface GenerateCharacterPassportCommand {
+  characterId: string;
+  requestedBy: "system" | "manual";
+}
+
+export interface CharacterPassportSourceSnapshot {
+  characterId: string;
+  name: string;
+  originGame: CharacterPassportV1["originGame"];
+  element: FivePhaseElement;
+  combatClass: CombatClass;
+  baseAttributes: BasicAttributeSet;
+  faith: FaithDraft;
+  growth: CharacterGrowth;
+  skills: SkillDefinition[];
+  abilities: AbilityDefinition[];
+}
+
+export interface CharacterPassportSourcePort {
+  loadCharacterPassportSource(command: GenerateCharacterPassportCommand): Promise<CharacterPassportSourceSnapshot | null>;
+}
+
+export interface GenerateCharacterPassportUseCase {
+  execute(command: GenerateCharacterPassportCommand): Promise<CharacterPassportV1 | null>;
+}

--- a/src/application/tactics/assembleTacticsUnit.ts
+++ b/src/application/tactics/assembleTacticsUnit.ts
@@ -1,0 +1,16 @@
+import type { CharacterPassportV1 } from "../../domain/passport/characterPassport";
+import type { TacticsTeam, TacticsUnitSnapshot } from "../../domain/tactics/unit";
+
+export interface AssembleTacticsUnitCommand {
+  unitId: string;
+  team: TacticsTeam;
+  passport: CharacterPassportV1;
+}
+
+export interface TacticsPassportReaderPort {
+  loadPassport(characterId: string): Promise<CharacterPassportV1 | null>;
+}
+
+export interface AssembleTacticsUnitUseCase {
+  execute(command: AssembleTacticsUnitCommand): TacticsUnitSnapshot;
+}

--- a/src/domain/passport/characterPassport.test.ts
+++ b/src/domain/passport/characterPassport.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { createCharacterPassportV1 } from "./characterPassport";
+import { createEmptyGrowth, createGrowthSourceTotals } from "./growth";
+import {
+  BUFF_BY_ELEMENT,
+  COMBAT_CLASS_BY_ELEMENT,
+  DEBUFF_BY_ELEMENT,
+  STATUS_CONDITION_BY_ELEMENT,
+  createBaseAttributes,
+} from "./fivePhases";
+
+function buildPassport() {
+  return createCharacterPassportV1({
+    characterId: "aki-passport",
+    name: "Aki",
+    originGame: "god-sandbox-mvp",
+    element: "wood",
+    combatClass: "ranger",
+    baseAttributes: createBaseAttributes({
+      vision: 6,
+      power: 2,
+      guard: 3,
+      discipline: 4,
+      flow: 5,
+    }),
+    faith: {
+      value: 82,
+      obedienceBias: "disciplined",
+      commandInterpretation: "contextual",
+      hazardResponse: "resolute",
+      autonomyAlignment: "balanced",
+      sources: createGrowthSourceTotals({
+        blessings: 3,
+        trials: 1,
+      }),
+    },
+    growth: createEmptyGrowth(),
+    skills: [
+      {
+        kind: "skill",
+        id: "thorn-trail",
+        name: "Thorn Trail",
+        element: "wood",
+        skillType: "control",
+        description: "枝の罠で敵の足を止める。",
+        targetPattern: "line",
+        range: 3,
+        powerPerTile: 1,
+        secondaryEffect: {
+          type: "statusCondition",
+          key: "rooted",
+          duration: 1,
+          target: "enemy",
+        },
+      },
+    ],
+    abilities: [
+      {
+        kind: "ability",
+        id: "grove-oath",
+        name: "Grove Oath",
+        source: "trial",
+        element: "wood",
+        abilityType: "reaction",
+        description: "拘束を受けた直後に姿勢を立て直す。",
+        trigger: {
+          type: "onStatusReceived",
+          status: "rooted",
+        },
+        effects: [
+          {
+            type: "buff",
+            key: "growth",
+            value: 1,
+            duration: 1,
+            target: "self",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+describe("character passport domain", () => {
+  it("keeps five-phase mappings aligned across class, status, buff, and debuff", () => {
+    expect(COMBAT_CLASS_BY_ELEMENT.wood).toBe("ranger");
+    expect(COMBAT_CLASS_BY_ELEMENT.water).toBe("healer");
+    expect(STATUS_CONDITION_BY_ELEMENT.metal).toBe("sealed");
+    expect(BUFF_BY_ELEMENT.earth).toBe("fortify");
+    expect(DEBUFF_BY_ELEMENT.fire).toBe("overheated");
+  });
+
+  it("models faith as command interpretation rather than a raw success chance", () => {
+    const passport = buildPassport();
+
+    expect(passport.faith.value).toBe(82);
+    expect(passport.faith.trustBand).toBe("devoted");
+    expect(passport.faith.commandInterpretation).toBe("contextual");
+    expect(passport.faith.hazardResponse).toBe("resolute");
+    expect(passport.faith.autonomyAlignment).toBe("balanced");
+  });
+
+  it("rejects an element and combat class mismatch", () => {
+    expect(() =>
+      createCharacterPassportV1({
+        ...buildPassport(),
+        element: "wood",
+        combatClass: "mage",
+      }),
+    ).toThrow(/Combat class mismatch/);
+  });
+
+  it("keeps skills and abilities as distinct boundaries in the passport", () => {
+    const passport = buildPassport();
+
+    expect(passport.skills[0]?.kind).toBe("skill");
+    expect(passport.skills[0]?.secondaryEffect?.type).toBe("statusCondition");
+    expect(passport.abilities[0]?.kind).toBe("ability");
+    expect(passport.abilities[0]?.trigger.type).toBe("onStatusReceived");
+    expect(passport.abilities[0]?.effects[0]?.type).toBe("buff");
+  });
+});

--- a/src/domain/passport/characterPassport.ts
+++ b/src/domain/passport/characterPassport.ts
@@ -1,0 +1,63 @@
+import { createFaith, type Faith, type FaithDraft } from "./faith";
+import { cloneGrowth, type CharacterGrowth } from "./growth";
+import {
+  getCombatClassForElement,
+  type BasicAttributeSet,
+  type CombatClass,
+  type FivePhaseElement,
+} from "./fivePhases";
+import type { AbilityDefinition, SkillDefinition } from "./skill";
+
+export const CHARACTER_PASSPORT_SCHEMA_VERSION = "character-passport/v1";
+export type CharacterPassportSchemaVersion = typeof CHARACTER_PASSPORT_SCHEMA_VERSION;
+
+export interface CharacterPassportDraft {
+  characterId: string;
+  name: string;
+  originGame: "god-sandbox-mvp";
+  element: FivePhaseElement;
+  combatClass: CombatClass;
+  baseAttributes: BasicAttributeSet;
+  faith: FaithDraft;
+  growth: CharacterGrowth;
+  skills: SkillDefinition[];
+  abilities: AbilityDefinition[];
+}
+
+export interface CharacterPassportV1 {
+  schemaVersion: CharacterPassportSchemaVersion;
+  characterId: string;
+  name: string;
+  originGame: "god-sandbox-mvp";
+  element: FivePhaseElement;
+  combatClass: CombatClass;
+  baseAttributes: BasicAttributeSet;
+  faith: Faith;
+  growth: CharacterGrowth;
+  skills: SkillDefinition[];
+  abilities: AbilityDefinition[];
+}
+
+export function createCharacterPassportV1(draft: CharacterPassportDraft): CharacterPassportV1 {
+  const expectedCombatClass = getCombatClassForElement(draft.element);
+
+  if (draft.combatClass !== expectedCombatClass) {
+    throw new Error(
+      `Combat class mismatch for ${draft.element}: expected ${expectedCombatClass}, received ${draft.combatClass}.`,
+    );
+  }
+
+  return {
+    schemaVersion: CHARACTER_PASSPORT_SCHEMA_VERSION,
+    characterId: draft.characterId,
+    name: draft.name,
+    originGame: draft.originGame,
+    element: draft.element,
+    combatClass: draft.combatClass,
+    baseAttributes: { ...draft.baseAttributes },
+    faith: createFaith(draft.faith),
+    growth: cloneGrowth(draft.growth),
+    skills: [...draft.skills],
+    abilities: [...draft.abilities],
+  };
+}

--- a/src/domain/passport/faith.ts
+++ b/src/domain/passport/faith.ts
@@ -1,0 +1,72 @@
+import { createGrowthSourceTotals, type GrowthSourceTotals } from "./growth";
+
+export const FAITH_OBEDIENCE_BIASES = [
+  "cautious",
+  "fervent",
+  "stable",
+  "disciplined",
+  "adaptive",
+] as const;
+export type FaithObedienceBias = (typeof FAITH_OBEDIENCE_BIASES)[number];
+
+export const FAITH_COMMAND_INTERPRETATIONS = ["skeptical", "measured", "literal", "contextual"] as const;
+export type FaithCommandInterpretation = (typeof FAITH_COMMAND_INTERPRETATIONS)[number];
+
+export const FAITH_HAZARD_RESPONSES = ["avoidant", "guarded", "resolute"] as const;
+export type FaithHazardResponse = (typeof FAITH_HAZARD_RESPONSES)[number];
+
+export const FAITH_AUTONOMY_ALIGNMENTS = ["selfDirected", "balanced", "deferential"] as const;
+export type FaithAutonomyAlignment = (typeof FAITH_AUTONOMY_ALIGNMENTS)[number];
+
+export const FAITH_TRUST_BANDS = ["dismissive", "wary", "steady", "trusting", "devoted"] as const;
+export type FaithTrustBand = (typeof FAITH_TRUST_BANDS)[number];
+
+export interface FaithDraft {
+  value: number;
+  obedienceBias: FaithObedienceBias;
+  commandInterpretation: FaithCommandInterpretation;
+  hazardResponse: FaithHazardResponse;
+  autonomyAlignment: FaithAutonomyAlignment;
+  sources: GrowthSourceTotals;
+}
+
+export interface Faith extends FaithDraft {
+  trustBand: FaithTrustBand;
+}
+
+export function clampFaithValue(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+export function getFaithTrustBand(value: number): FaithTrustBand {
+  const normalized = clampFaithValue(value);
+
+  if (normalized <= 20) {
+    return "dismissive";
+  }
+
+  if (normalized <= 40) {
+    return "wary";
+  }
+
+  if (normalized <= 60) {
+    return "steady";
+  }
+
+  if (normalized <= 80) {
+    return "trusting";
+  }
+
+  return "devoted";
+}
+
+export function createFaith(draft: FaithDraft): Faith {
+  const value = clampFaithValue(draft.value);
+
+  return {
+    ...draft,
+    value,
+    trustBand: getFaithTrustBand(value),
+    sources: createGrowthSourceTotals(draft.sources),
+  };
+}

--- a/src/domain/passport/fivePhases.ts
+++ b/src/domain/passport/fivePhases.ts
@@ -1,0 +1,112 @@
+export const FIVE_PHASE_ELEMENTS = ["wood", "fire", "earth", "metal", "water"] as const;
+export type FivePhaseElement = (typeof FIVE_PHASE_ELEMENTS)[number];
+
+export const COMBAT_CLASSES = ["ranger", "mage", "guardian", "knight", "healer"] as const;
+export type CombatClass = (typeof COMBAT_CLASSES)[number];
+
+export const COMBAT_CLASS_BY_ELEMENT = {
+  wood: "ranger",
+  fire: "mage",
+  earth: "guardian",
+  metal: "knight",
+  water: "healer",
+} as const satisfies Record<FivePhaseElement, CombatClass>;
+
+export const ELEMENT_BY_COMBAT_CLASS = {
+  ranger: "wood",
+  mage: "fire",
+  guardian: "earth",
+  knight: "metal",
+  healer: "water",
+} as const satisfies Record<CombatClass, FivePhaseElement>;
+
+export const BASIC_ATTRIBUTES = ["vision", "power", "guard", "discipline", "flow"] as const;
+export type BasicAttribute = (typeof BASIC_ATTRIBUTES)[number];
+
+export const BASIC_ATTRIBUTE_BY_ELEMENT = {
+  wood: "vision",
+  fire: "power",
+  earth: "guard",
+  metal: "discipline",
+  water: "flow",
+} as const satisfies Record<FivePhaseElement, BasicAttribute>;
+
+export const STATUS_CONDITIONS = ["rooted", "burning", "burdened", "sealed", "chilled"] as const;
+export type StatusCondition = (typeof STATUS_CONDITIONS)[number];
+
+export const STATUS_CONDITION_BY_ELEMENT = {
+  wood: "rooted",
+  fire: "burning",
+  earth: "burdened",
+  metal: "sealed",
+  water: "chilled",
+} as const satisfies Record<FivePhaseElement, StatusCondition>;
+
+export const BUFFS = ["growth", "ignite", "fortify", "focus", "flowing"] as const;
+export type TacticsBuff = (typeof BUFFS)[number];
+
+export const BUFF_BY_ELEMENT = {
+  wood: "growth",
+  fire: "ignite",
+  earth: "fortify",
+  metal: "focus",
+  water: "flowing",
+} as const satisfies Record<FivePhaseElement, TacticsBuff>;
+
+export const DEBUFFS = ["entangled", "overheated", "crumbled", "fractured", "displaced"] as const;
+export type TacticsDebuff = (typeof DEBUFFS)[number];
+
+export const DEBUFF_BY_ELEMENT = {
+  wood: "entangled",
+  fire: "overheated",
+  earth: "crumbled",
+  metal: "fractured",
+  water: "displaced",
+} as const satisfies Record<FivePhaseElement, TacticsDebuff>;
+
+export type FivePhaseValueMap<T> = Record<FivePhaseElement, T>;
+export type BasicAttributeSet = Record<BasicAttribute, number>;
+
+export function getCombatClassForElement(element: FivePhaseElement): CombatClass {
+  return COMBAT_CLASS_BY_ELEMENT[element];
+}
+
+export function getElementForCombatClass(combatClass: CombatClass): FivePhaseElement {
+  return ELEMENT_BY_COMBAT_CLASS[combatClass];
+}
+
+export function getBasicAttributeForElement(element: FivePhaseElement): BasicAttribute {
+  return BASIC_ATTRIBUTE_BY_ELEMENT[element];
+}
+
+export function getStatusConditionForElement(element: FivePhaseElement): StatusCondition {
+  return STATUS_CONDITION_BY_ELEMENT[element];
+}
+
+export function getBuffForElement(element: FivePhaseElement): TacticsBuff {
+  return BUFF_BY_ELEMENT[element];
+}
+
+export function getDebuffForElement(element: FivePhaseElement): TacticsDebuff {
+  return DEBUFF_BY_ELEMENT[element];
+}
+
+export function createFivePhaseValues(values: Partial<FivePhaseValueMap<number>> = {}): FivePhaseValueMap<number> {
+  return {
+    wood: values.wood ?? 0,
+    fire: values.fire ?? 0,
+    earth: values.earth ?? 0,
+    metal: values.metal ?? 0,
+    water: values.water ?? 0,
+  };
+}
+
+export function createBaseAttributes(values: Partial<BasicAttributeSet> = {}): BasicAttributeSet {
+  return {
+    vision: values.vision ?? 0,
+    power: values.power ?? 0,
+    guard: values.guard ?? 0,
+    discipline: values.discipline ?? 0,
+    flow: values.flow ?? 0,
+  };
+}

--- a/src/domain/passport/growth.ts
+++ b/src/domain/passport/growth.ts
@@ -1,0 +1,37 @@
+import { createFivePhaseValues, type FivePhaseValueMap } from "./fivePhases";
+
+export const GROWTH_CATEGORIES = ["blessings", "trials", "chaosExposure"] as const;
+export type GrowthCategory = (typeof GROWTH_CATEGORIES)[number];
+
+export type GrowthVector = FivePhaseValueMap<number>;
+export type GrowthSourceTotals = Record<GrowthCategory, number>;
+
+export interface CharacterGrowth {
+  blessings: GrowthVector;
+  trials: GrowthVector;
+  chaosExposure: GrowthVector;
+}
+
+export function createGrowthSourceTotals(values: Partial<GrowthSourceTotals> = {}): GrowthSourceTotals {
+  return {
+    blessings: values.blessings ?? 0,
+    trials: values.trials ?? 0,
+    chaosExposure: values.chaosExposure ?? 0,
+  };
+}
+
+export function createEmptyGrowth(): CharacterGrowth {
+  return {
+    blessings: createFivePhaseValues(),
+    trials: createFivePhaseValues(),
+    chaosExposure: createFivePhaseValues(),
+  };
+}
+
+export function cloneGrowth(growth: CharacterGrowth): CharacterGrowth {
+  return {
+    blessings: createFivePhaseValues(growth.blessings),
+    trials: createFivePhaseValues(growth.trials),
+    chaosExposure: createFivePhaseValues(growth.chaosExposure),
+  };
+}

--- a/src/domain/passport/skill.ts
+++ b/src/domain/passport/skill.ts
@@ -1,0 +1,75 @@
+import type { FivePhaseElement, StatusCondition, TacticsBuff, TacticsDebuff } from "./fivePhases";
+
+export const ABILITY_SOURCES = ["class", "blessing", "trial", "chaos"] as const;
+export type AbilitySource = (typeof ABILITY_SOURCES)[number];
+
+export const ABILITY_TYPES = ["passive", "reaction", "aura"] as const;
+export type AbilityType = (typeof ABILITY_TYPES)[number];
+
+export const SKILL_TYPES = ["attack", "heal", "move", "support", "control"] as const;
+export type SkillType = (typeof SKILL_TYPES)[number];
+
+export const ABILITY_TRIGGER_TYPES = [
+  "onTurnStart",
+  "onTurnEnd",
+  "onStatusReceived",
+  "onAllyDamaged",
+  "onFaithCommand",
+  "manual",
+] as const;
+export type AbilityTriggerType = (typeof ABILITY_TRIGGER_TYPES)[number];
+
+export const EFFECT_TYPES = [
+  "buff",
+  "debuff",
+  "statusCondition",
+  "heal",
+  "damage",
+  "move",
+  "cleanse",
+  "summon",
+  "modifyFaith",
+] as const;
+export type EffectType = (typeof EFFECT_TYPES)[number];
+
+export const EFFECT_TARGETS = ["self", "ally", "enemy", "area"] as const;
+export type EffectTarget = (typeof EFFECT_TARGETS)[number];
+
+export type AbilityTrigger =
+  | { type: "onTurnStart" | "onTurnEnd" | "onAllyDamaged" | "manual" }
+  | { type: "onStatusReceived"; status: StatusCondition }
+  | { type: "onFaithCommand"; commandTag: string };
+
+export type TacticsEffect =
+  | { type: "buff"; key: TacticsBuff; value: number; duration: number; target: EffectTarget }
+  | { type: "debuff"; key: TacticsDebuff; value: number; duration: number; target: EffectTarget }
+  | { type: "statusCondition"; key: StatusCondition; duration: number; target: EffectTarget }
+  | { type: "heal" | "damage" | "move"; value: number; target: EffectTarget }
+  | { type: "cleanse"; target: EffectTarget; key?: StatusCondition | TacticsDebuff }
+  | { type: "summon"; value: number; target: "self" | "area" }
+  | { type: "modifyFaith"; value: number; target: "self" | "ally" };
+
+export interface SkillDefinition {
+  kind: "skill";
+  id: string;
+  name: string;
+  element: FivePhaseElement;
+  skillType: SkillType;
+  description: string;
+  targetPattern: string;
+  range: number;
+  powerPerTile: number;
+  secondaryEffect?: TacticsEffect;
+}
+
+export interface AbilityDefinition {
+  kind: "ability";
+  id: string;
+  name: string;
+  source: AbilitySource;
+  element: FivePhaseElement;
+  abilityType: AbilityType;
+  description: string;
+  trigger: AbilityTrigger;
+  effects: TacticsEffect[];
+}

--- a/src/domain/tactics/unit.ts
+++ b/src/domain/tactics/unit.ts
@@ -1,0 +1,41 @@
+import type { Faith } from "../passport/faith";
+import type { AbilityDefinition, SkillDefinition } from "../passport/skill";
+import type {
+  BasicAttributeSet,
+  CombatClass,
+  FivePhaseElement,
+  StatusCondition,
+  TacticsBuff,
+  TacticsDebuff,
+} from "../passport/fivePhases";
+
+export const TACTICS_TEAMS = ["allies", "enemies", "neutral"] as const;
+export type TacticsTeam = (typeof TACTICS_TEAMS)[number];
+
+export interface TacticsUnitStatusBoard {
+  conditions: StatusCondition[];
+  buffs: Partial<Record<TacticsBuff, number>>;
+  debuffs: Partial<Record<TacticsDebuff, number>>;
+}
+
+export interface TacticsUnitSnapshot {
+  unitId: string;
+  passportId: string;
+  name: string;
+  team: TacticsTeam;
+  element: FivePhaseElement;
+  combatClass: CombatClass;
+  baseAttributes: BasicAttributeSet;
+  faith: Faith;
+  skills: SkillDefinition[];
+  abilities: AbilityDefinition[];
+  statusBoard: TacticsUnitStatusBoard;
+}
+
+export function createEmptyTacticsUnitStatusBoard(): TacticsUnitStatusBoard {
+  return {
+    conditions: [],
+    buffs: {},
+    debuffs: {},
+  };
+}


### PR DESCRIPTION
## 概要
- Character Passport と tactics 戦闘に向けた domain model を追加
- 五行と職種の 1:1 対応、基本ステータス、状態異常、バフ、デバフの固定対応を定義
- Faith を命令成功率ではなく、命令解釈・危険命令への反応・自律判断とのせめぎ合いを表せる最小モデルとして定義
- growth / skill / ability / Character Passport v1 / tactics unit の最小型を追加
- Character Passport 生成と tactics unit 組み立ての application boundary を追加

## 変更ファイル
- src/domain/passport/fivePhases.ts
- src/domain/passport/growth.ts
- src/domain/passport/faith.ts
- src/domain/passport/skill.ts
- src/domain/passport/characterPassport.ts
- src/domain/passport/characterPassport.test.ts
- src/domain/tactics/unit.ts
- src/application/passport/generateCharacterPassport.ts
- src/application/tactics/assembleTacticsUnit.ts

## 今回やらないこと
- frontend UI 変更
- provider 設定 UI
- 実 LLM 接続
- Character Passport の export 実装
- server / REST API / file storage 実装
- tactics の実戦闘ロジック、map / grid / pathfinding、balancing
- package 変更
- CI workflow 変更

## 独立性
- レーンAの担当範囲のみを変更
- src/application/utterance/** は未変更
- src/infrastructure/** は未変更
- src/presentation/** は未変更
- レーンBの utterance provider 実装とは独立です

## 確認
- npm run typecheck
- npm run build
- vitest run src/domain/world.test.ts src/domain/passport/characterPassport.test.ts