### PR TITLE
Character Passport export adapter を Domain 契約へ接続

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -109,22 +109,38 @@ npm run data:smoke
 
 # god-sandbox-character-passport
 
-Character Passport v1 のローカル出力層です (PBI-BE-FS-002)。
+Character Passport v1 のローカル出力層です。
 
 箱庭で育てたキャラクターを、あとで別ゲームへ持ち出すための JSON を作ります。
-今回は **ローカルファイルへ出力するだけ** です。REST API やフロント接続は行いません。
+今回は **ローカルファイルへ出力するだけ** で、REST API やフロント接続は行いません。
+
+## 接続方針
+
+Character Passport の意味は `src/domain/passport/**` を正とします。
+server 側は、その意味を import して会話モデル化するのではなく、**export 契約の整形と file write を吸収する adapter** として扱います。
+
+```text
+Application source snapshot / Domain draft
+  -> server/character-passport.mjs
+  -> Character Passport export JSON
+  -> god-sandbox-data/exports/character-passports/*.json
+```
+
+`Character Passport JSON` は export contract であり、内部会話モデルではありません。
 
 ## 何ができるか
 
-- Character Passport v1 の JSON を作る
+- Character Passport v1 の export JSON を組み立てる
+- Application source snapshot から export 形へ変換する
 - `god-sandbox-data/exports/character-passports/` に保存する
-- smoke コマンドで、初見の開発者でも出力結果をすぐ確認できる
+- smoke コマンドで、adapter と file write の最小確認ができる
 
 ## 主要API
 
 | 関数 | 説明 |
 |---|---|
-| `createCharacterPassportV1(input)` | Character Passport v1 の JSON を組み立てる |
+| `createCharacterPassportV1(input)` | Domain 寄りの draft から Character Passport v1 export JSON を組み立てる |
+| `adaptCharacterPassportSourceToExport(source)` | Application source snapshot を export JSON へ変換する adapter |
 | `writeCharacterPassportFile(passport)` | Passport JSON をローカルファイルへ保存する |
 
 ## Character Passport v1 の最小仕様
@@ -137,40 +153,88 @@ Character Passport v1 のローカル出力層です (PBI-BE-FS-002)。
   "characterId": "sample-ren",
   "name": "Ren",
   "originGame": "god-sandbox-mvp",
-  "combatClass": "rogue",
+  "element": "metal",
+  "combatClass": "knight",
+  "baseAttributes": {
+    "vision": 2,
+    "power": 3,
+    "guard": 5,
+    "discipline": 6,
+    "flow": 2
+  },
   "faith": {
     "value": 50,
-    "obedienceBias": "cautious"
+    "obedienceBias": "cautious",
+    "commandInterpretation": "measured",
+    "hazardResponse": "guarded",
+    "autonomyAlignment": "balanced",
+    "trustBand": "steady",
+    "sources": {
+      "blessings": 1,
+      "trials": 2,
+      "chaosExposure": 0
+    }
   },
-  "attributes": {
-    "hp": 8,
-    "attack": 3,
-    "defense": 2,
-    "will": 4,
-    "vision": 5,
-    "stealth": 3,
-    "support": 1,
-    "chaosAffinity": 2
+  "growth": {
+    "blessings": {
+      "wood": 0,
+      "fire": 0,
+      "earth": 0,
+      "metal": 1,
+      "water": 0
+    },
+    "trials": {
+      "wood": 0,
+      "fire": 0,
+      "earth": 1,
+      "metal": 2,
+      "water": 0
+    },
+    "chaosExposure": {
+      "wood": 0,
+      "fire": 0,
+      "earth": 0,
+      "metal": 0,
+      "water": 0
+    }
   },
-  "abilities": [],
-  "history": {
-    "blessings": [],
-    "trials": [],
-    "chaosEvents": []
-  }
+  "skills": [],
+  "abilities": []
 }
 ```
 
-### `combatClass`
+## 既存 server-only prototype との差分
 
-今の v1 では次の 4 種のみ許可します。
+以前の `server/character-passport.mjs` は、`attributes` / `history` / `rogue` などの server-only 仮スキーマを持っていました。
+PBI-PASSPORT-EXPORT-INTEGRATION-001 以降は、それを延命せず、Domain で確定した次の意味へ寄せます。
 
-- `vanguard`
+- `element` と `combatClass` は 1:1 固定
+- `baseAttributes` は `vision / power / guard / discipline / flow`
+- `faith` は value だけでなく、命令解釈・危険命令への反応・自律判断寄りの項目を含む
+- `growth` は `blessings / trials / chaosExposure` を五行ごとに持つ
+- `skills` は能動行動、`abilities` は受動 / 反応 / aura 効果
+
+## `combatClass`
+
+v1 では次の 5 種のみ許可します。
+
+- `ranger`
 - `mage`
-- `rogue`
+- `guardian`
+- `knight`
 - `healer`
 
-### `characterId`
+対応は固定です。
+
+```text
+wood  = ranger
+fire  = mage
+earth = guardian
+metal = knight
+water = healer
+```
+
+## `characterId`
 
 `characterId` は export ファイル名に使われます。
 安全のため、空文字、`/`、`\`、`..` を含む値は拒否します。
@@ -192,11 +256,13 @@ god-sandbox-data/
 npm run passport:smoke
 ```
 
-これで次の 3 点を確認できます。
+これで次の 5 点を確認できます。
 
-1. Passport JSON が生成できる
+1. Domain 寄りの Passport export JSON が生成できる
 2. `god-sandbox-data/exports/character-passports/` に保存できる
 3. `schemaVersion` が `character-passport/v1` になっている
+4. `element` と `combatClass` の固定対応違反を拒否できる
+5. `characterId` の path traversal / slash を拒否できる
 
 ## 今回まだ含まないもの
 

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -1,12 +1,26 @@
-import { writeFile, readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { join, resolve } from 'path';
 
 import { initDirs } from './local-game-data.mjs';
 
 const DATA_ROOT = resolve(process.cwd(), 'god-sandbox-data');
 const PASSPORT_DIR = join(DATA_ROOT, 'exports', 'character-passports');
-
-const VALID_CLASSES = new Set(['vanguard', 'mage', 'rogue', 'healer']);
+const SCHEMA_VERSION = 'character-passport/v1';
+const FIVE_PHASE_KEYS = ['wood', 'fire', 'earth', 'metal', 'water'];
+const BASE_ATTRIBUTE_KEYS = ['vision', 'power', 'guard', 'discipline', 'flow'];
+const VALID_ELEMENTS = new Set(FIVE_PHASE_KEYS);
+const VALID_CLASSES = new Set(['ranger', 'mage', 'guardian', 'knight', 'healer']);
+const VALID_OBEDIENCE_BIASES = new Set(['cautious', 'fervent', 'stable', 'disciplined', 'adaptive']);
+const VALID_COMMAND_INTERPRETATIONS = new Set(['skeptical', 'measured', 'literal', 'contextual']);
+const VALID_HAZARD_RESPONSES = new Set(['avoidant', 'guarded', 'resolute']);
+const VALID_AUTONOMY_ALIGNMENTS = new Set(['selfDirected', 'balanced', 'deferential']);
+const COMBAT_CLASS_BY_ELEMENT = {
+  wood: 'ranger',
+  fire: 'mage',
+  earth: 'guardian',
+  metal: 'knight',
+  water: 'healer',
+};
 
 function assertSafeName(name, label) {
   if (!name || typeof name !== 'string') {
@@ -17,47 +31,200 @@ function assertSafeName(name, label) {
   }
 }
 
-function assertCombatClass(combatClass) {
-  if (!VALID_CLASSES.has(combatClass)) {
-    throw new Error(`Invalid combatClass "${combatClass}". Expected one of: ${Array.from(VALID_CLASSES).join(', ')}`);
+function assertNonEmptyString(value, label) {
+  if (!value || typeof value !== 'string') {
+    throw new Error(`Invalid ${label}: must be a non-empty string.`);
+  }
+}
+
+function assertFiniteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Invalid ${label}: must be a finite number.`);
+  }
+}
+
+function assertPlainObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid ${label}: must be an object.`);
+  }
+}
+
+function assertArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid ${label}: must be an array.`);
+  }
+}
+
+function assertEnum(value, set, label) {
+  if (!set.has(value)) {
+    throw new Error(`Invalid ${label} "${value}". Expected one of: ${Array.from(set).join(', ')}`);
+  }
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function clampFaithValue(value) {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function getFaithTrustBand(value) {
+  if (value <= 20) {
+    return 'dismissive';
+  }
+
+  if (value <= 40) {
+    return 'wary';
+  }
+
+  if (value <= 60) {
+    return 'steady';
+  }
+
+  if (value <= 80) {
+    return 'trusting';
+  }
+
+  return 'devoted';
+}
+
+function assertFivePhaseValueMap(record, label) {
+  assertPlainObject(record, label);
+
+  for (const key of FIVE_PHASE_KEYS) {
+    assertFiniteNumber(record[key], `${label}.${key}`);
+  }
+}
+
+function normalizeBaseAttributes(baseAttributes) {
+  assertPlainObject(baseAttributes, 'baseAttributes');
+
+  for (const key of BASE_ATTRIBUTE_KEYS) {
+    assertFiniteNumber(baseAttributes[key], `baseAttributes.${key}`);
+  }
+
+  return {
+    vision: baseAttributes.vision,
+    power: baseAttributes.power,
+    guard: baseAttributes.guard,
+    discipline: baseAttributes.discipline,
+    flow: baseAttributes.flow,
+  };
+}
+
+function normalizeFaith(faith) {
+  assertPlainObject(faith, 'faith');
+  assertFiniteNumber(faith.value, 'faith.value');
+  assertEnum(faith.obedienceBias, VALID_OBEDIENCE_BIASES, 'faith.obedienceBias');
+  assertEnum(faith.commandInterpretation, VALID_COMMAND_INTERPRETATIONS, 'faith.commandInterpretation');
+  assertEnum(faith.hazardResponse, VALID_HAZARD_RESPONSES, 'faith.hazardResponse');
+  assertEnum(faith.autonomyAlignment, VALID_AUTONOMY_ALIGNMENTS, 'faith.autonomyAlignment');
+  assertPlainObject(faith.sources, 'faith.sources');
+  assertFiniteNumber(faith.sources.blessings, 'faith.sources.blessings');
+  assertFiniteNumber(faith.sources.trials, 'faith.sources.trials');
+  assertFiniteNumber(faith.sources.chaosExposure, 'faith.sources.chaosExposure');
+
+  const value = clampFaithValue(faith.value);
+
+  return {
+    value,
+    obedienceBias: faith.obedienceBias,
+    commandInterpretation: faith.commandInterpretation,
+    hazardResponse: faith.hazardResponse,
+    autonomyAlignment: faith.autonomyAlignment,
+    trustBand: getFaithTrustBand(value),
+    sources: {
+      blessings: faith.sources.blessings,
+      trials: faith.sources.trials,
+      chaosExposure: faith.sources.chaosExposure,
+    },
+  };
+}
+
+function normalizeGrowth(growth) {
+  assertPlainObject(growth, 'growth');
+  assertFivePhaseValueMap(growth.blessings, 'growth.blessings');
+  assertFivePhaseValueMap(growth.trials, 'growth.trials');
+  assertFivePhaseValueMap(growth.chaosExposure, 'growth.chaosExposure');
+
+  return {
+    blessings: cloneJson(growth.blessings),
+    trials: cloneJson(growth.trials),
+    chaosExposure: cloneJson(growth.chaosExposure),
+  };
+}
+
+function normalizeSkills(skills) {
+  assertArray(skills, 'skills');
+
+  return skills.map((skill, index) => {
+    assertPlainObject(skill, `skills[${index}]`);
+    assertNonEmptyString(skill.id, `skills[${index}].id`);
+    assertNonEmptyString(skill.name, `skills[${index}].name`);
+    assertEnum(skill.kind, new Set(['skill']), `skills[${index}].kind`);
+    assertEnum(skill.element, VALID_ELEMENTS, `skills[${index}].element`);
+
+    return cloneJson(skill);
+  });
+}
+
+function normalizeAbilities(abilities) {
+  assertArray(abilities, 'abilities');
+
+  return abilities.map((ability, index) => {
+    assertPlainObject(ability, `abilities[${index}]`);
+    assertNonEmptyString(ability.id, `abilities[${index}].id`);
+    assertNonEmptyString(ability.name, `abilities[${index}].name`);
+    assertEnum(ability.kind, new Set(['ability']), `abilities[${index}].kind`);
+    assertEnum(ability.element, VALID_ELEMENTS, `abilities[${index}].element`);
+
+    return cloneJson(ability);
+  });
+}
+
+function assertCombatClassMatchesElement(element, combatClass) {
+  const expectedCombatClass = COMBAT_CLASS_BY_ELEMENT[element];
+
+  if (combatClass !== expectedCombatClass) {
+    throw new Error(
+      `Combat class mismatch for ${element}: expected ${expectedCombatClass}, received ${combatClass}.`,
+    );
   }
 }
 
 export function createCharacterPassportV1(input) {
   assertSafeName(input.characterId, 'characterId');
-  assertCombatClass(input.combatClass);
+  assertNonEmptyString(input.name, 'name');
+  if (input.originGame && input.originGame !== 'god-sandbox-mvp') {
+    throw new Error(`Invalid originGame "${input.originGame}". Expected god-sandbox-mvp.`);
+  }
+  assertEnum(input.element, VALID_ELEMENTS, 'element');
+  assertEnum(input.combatClass, VALID_CLASSES, 'combatClass');
+  assertCombatClassMatchesElement(input.element, input.combatClass);
 
   return {
-    schemaVersion: 'character-passport/v1',
+    schemaVersion: SCHEMA_VERSION,
     characterId: input.characterId,
     name: input.name,
     originGame: 'god-sandbox-mvp',
+    element: input.element,
     combatClass: input.combatClass,
-    faith: {
-      value: input.faith.value,
-      obedienceBias: input.faith.obedienceBias,
-    },
-    attributes: {
-      hp: input.attributes.hp,
-      attack: input.attributes.attack,
-      defense: input.attributes.defense,
-      will: input.attributes.will,
-      vision: input.attributes.vision,
-      stealth: input.attributes.stealth,
-      support: input.attributes.support,
-      chaosAffinity: input.attributes.chaosAffinity,
-    },
-    abilities: [...input.abilities],
-    history: {
-      blessings: [...input.history.blessings],
-      trials: [...input.history.trials],
-      chaosEvents: [...input.history.chaosEvents],
-    },
+    baseAttributes: normalizeBaseAttributes(input.baseAttributes),
+    faith: normalizeFaith(input.faith),
+    growth: normalizeGrowth(input.growth),
+    skills: normalizeSkills(input.skills),
+    abilities: normalizeAbilities(input.abilities),
   };
 }
 
+// server 側は Domain / Application の意味を前提に、export 契約と file write を吸収する。
+export function adaptCharacterPassportSourceToExport(source) {
+  return createCharacterPassportV1(source);
+}
+
 export async function writeCharacterPassportFile(passport) {
-  if (passport.schemaVersion !== 'character-passport/v1') {
+  if (passport.schemaVersion !== SCHEMA_VERSION) {
     throw new Error(`Unexpected schemaVersion: ${passport.schemaVersion}`);
   }
   assertSafeName(passport.characterId, 'characterId');
@@ -70,47 +237,128 @@ export async function writeCharacterPassportFile(passport) {
   return filePath;
 }
 
-function sampleRenPassport() {
-  return createCharacterPassportV1({
+function emptyFivePhaseValues(overrides = {}) {
+  return {
+    wood: overrides.wood ?? 0,
+    fire: overrides.fire ?? 0,
+    earth: overrides.earth ?? 0,
+    metal: overrides.metal ?? 0,
+    water: overrides.water ?? 0,
+  };
+}
+
+function sampleRenPassportSource() {
+  return {
     characterId: 'sample-ren',
     name: 'Ren',
-    combatClass: 'rogue',
+    originGame: 'god-sandbox-mvp',
+    element: 'metal',
+    combatClass: 'knight',
+    baseAttributes: {
+      vision: 2,
+      power: 3,
+      guard: 5,
+      discipline: 6,
+      flow: 2,
+    },
     faith: {
       value: 50,
       obedienceBias: 'cautious',
+      commandInterpretation: 'measured',
+      hazardResponse: 'guarded',
+      autonomyAlignment: 'balanced',
+      sources: {
+        blessings: 1,
+        trials: 2,
+        chaosExposure: 0,
+      },
     },
-    attributes: {
-      hp: 8,
-      attack: 3,
-      defense: 2,
-      will: 4,
-      vision: 5,
-      stealth: 3,
-      support: 1,
-      chaosAffinity: 2,
+    growth: {
+      blessings: emptyFivePhaseValues({ metal: 1 }),
+      trials: emptyFivePhaseValues({ metal: 2, earth: 1 }),
+      chaosExposure: emptyFivePhaseValues(),
     },
-    abilities: [],
-    history: {
-      blessings: [],
-      trials: [],
-      chaosEvents: [],
-    },
-  });
+    skills: [
+      {
+        kind: 'skill',
+        id: 'iron-lunge',
+        name: 'Iron Lunge',
+        element: 'metal',
+        skillType: 'attack',
+        description: '前線を押し込みながら制約を刻む。',
+        targetPattern: 'line',
+        range: 2,
+        powerPerTile: 2,
+        secondaryEffect: {
+          type: 'debuff',
+          key: 'fractured',
+          value: 1,
+          duration: 1,
+          target: 'enemy',
+        },
+      },
+    ],
+    abilities: [
+      {
+        kind: 'ability',
+        id: 'iron-vow',
+        name: 'Iron Vow',
+        source: 'trial',
+        element: 'metal',
+        abilityType: 'reaction',
+        description: '封印を受けた直後、規律へ変換する。',
+        trigger: {
+          type: 'onStatusReceived',
+          status: 'sealed',
+        },
+        effects: [
+          {
+            type: 'buff',
+            key: 'focus',
+            value: 1,
+            duration: 1,
+            target: 'self',
+          },
+        ],
+      },
+    ],
+  };
 }
 
 if (process.argv[2] === 'smoke') {
   console.log('passport:smoke start');
 
-  const passport = sampleRenPassport();
+  const passport = adaptCharacterPassportSourceToExport(sampleRenPassportSource());
   const filePath = await writeCharacterPassportFile(passport);
   const saved = JSON.parse(await readFile(filePath, 'utf-8'));
 
-  if (saved.schemaVersion !== 'character-passport/v1') {
+  if (saved.schemaVersion !== SCHEMA_VERSION) {
     throw new Error(`Unexpected schemaVersion: ${saved.schemaVersion}`);
+  }
+
+  if (saved.element !== 'metal' || saved.combatClass !== 'knight') {
+    throw new Error('Expected element/combatClass mapping to be preserved.');
+  }
+
+  if (saved.faith.trustBand !== 'steady') {
+    throw new Error(`Expected trustBand steady, received ${saved.faith.trustBand}`);
+  }
+
+  if (saved.skills.length !== 1 || saved.abilities.length !== 1) {
+    throw new Error('Expected one skill and one ability in the exported sample.');
   }
 
   console.log('passport file:', filePath);
   console.log('passport schema ok:', saved.schemaVersion);
+  console.log('passport adapter ok:', `${saved.element}/${saved.combatClass}`);
+
+  try {
+    createCharacterPassportV1({ ...sampleRenPassportSource(), combatClass: 'mage' });
+    console.error('FAIL: should have rejected element/combatClass mismatch');
+    process.exit(1);
+  } catch (err) {
+    console.log('mapping mismatch rejected:', err.message);
+  }
 
   try {
     await writeCharacterPassportFile({ ...passport, characterId: '../outside' });


### PR DESCRIPTION
Closes #50

## 概要
- Character Passport の意味は Domain 側を正とし、server 側では export adapter と file write を吸収する方針へ整理
- `server/character-passport.mjs` を Domain 寄りの Character Passport v1 export 形へ更新
- Application source snapshot を export JSON へ変換する最小 adapter を追加
- `npm run passport:smoke` で export 生成、固定対応違反拒否、path traversal 拒否を確認できるようにした
- `server/README.md` に export 契約と接続方針を追記

## 変更ファイル
- `server/character-passport.mjs`
- `server/README.md`

## 方針
- Character Passport の意味は `src/domain/passport/**` を正とする
- server 側は Domain / Application の意味を import して会話モデル化せず、export 契約整形と file write を担当する
- 旧 server-only prototype (`attributes` / `history` / `rogue` など) は延命せず、Domain で定義された `element` / `combatClass` / `baseAttributes` / `faith` / `growth` / `skills` / `abilities` に寄せる

## 今回やらないこと
- REST API 拡張
- file storage 大改修
- UI 表示
- tactics battle logic
- LLM 発話統合
- package 変更
- CI workflow 変更

## 範囲確認
- `src/domain/**` は未変更
- `src/application/utterance/**` は未変更
- `src/infrastructure/llm/**` は未変更
- `src/presentation/**` は未変更
- frontend UI 変更なし

## 確認
- `npm run passport:smoke`
- `npm run build`