### PR TITLE
ui: Mock / Template 発話 limited UI を追加する

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -3,6 +3,13 @@ import { ApostlePanel } from "../features/apostle/ApostlePanel";
 import { CommandConsole } from "../features/commands/CommandConsole";
 import { EventModal } from "../features/events/EventModal";
 import { WorldViewport } from "../features/sandbox/WorldViewport";
+import { createMockProvider } from "../infrastructure/llm/mockProvider";
+import { createTemplateProvider } from "../infrastructure/llm/templateProvider";
+import { buildUtterancePreviewRequest } from "../presentation/utterance/buildUtterancePreviewRequest";
+import {
+  UtterancePreviewPanel,
+  type UtterancePreviewResult,
+} from "../presentation/utterance/UtterancePreviewPanel";
 import {
   getAliveCharacterCount,
   getBloodlineSummaries,
@@ -17,6 +24,11 @@ interface AppShellProps {
   userName: string;
   onLogout: () => void;
 }
+
+const UTTERANCE_PREVIEW_PROVIDERS = [
+  { label: "mockProvider", provider: createMockProvider() },
+  { label: "templateProvider", provider: createTemplateProvider() },
+];
 
 export function AppShell({ userName, onLogout }: AppShellProps) {
   const [state, dispatch] = useAppState();
@@ -49,6 +61,33 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
 
     return () => window.clearInterval(timerId);
   }, [dispatch, hasLivingCharacters, state.phase, state.timeControl]);
+
+  async function generateUtterancePreview(): Promise<UtterancePreviewResult[]> {
+    if (!focusedCharacter) {
+      return [];
+    }
+
+    const request = buildUtterancePreviewRequest({
+      character: focusedCharacter,
+      latestEventSummary: state.latestEventSummary,
+      latestJudgement: state.latestJudgement,
+      tick: state.tick,
+    });
+
+    const responses = await Promise.all(
+      UTTERANCE_PREVIEW_PROVIDERS.map(async ({ label, provider }) => ({
+        label,
+        response: await provider.generate(request),
+      })),
+    );
+
+    return responses.map(({ label, response }) => ({
+      providerLabel: label,
+      status: response.status,
+      text: response.text,
+      reason: response.reason,
+    }));
+  }
 
   return (
     <div className="app-shell">
@@ -151,6 +190,12 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
             paused={state.phase === "event"}
             onSelectCharacter={(characterId) => dispatch({ type: "selectFocus", characterId })}
             onTriggerManualEvent={() => dispatch({ type: "triggerManualEvent" })}
+          />
+
+          <UtterancePreviewPanel
+            disabled={!hasLivingCharacters}
+            focusedCharacter={focusedCharacter}
+            onGenerate={generateUtterancePreview}
           />
 
           <CommandConsole

--- a/src/presentation/utterance/UtterancePreviewPanel.tsx
+++ b/src/presentation/utterance/UtterancePreviewPanel.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import type { Character } from "../../domain/types";
+
+export interface UtterancePreviewResult {
+  providerLabel: string;
+  status: "ok" | "unavailable" | "no-utterance";
+  text: string | null;
+  reason?: string;
+}
+
+interface UtterancePreviewPanelProps {
+  focusedCharacter?: Character;
+  disabled: boolean;
+  onGenerate: () => Promise<UtterancePreviewResult[]>;
+}
+
+export function UtterancePreviewPanel({
+  focusedCharacter,
+  disabled,
+  onGenerate,
+}: UtterancePreviewPanelProps) {
+  const [results, setResults] = useState<UtterancePreviewResult[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const canGenerate = Boolean(focusedCharacter?.alive) && !disabled && !isGenerating;
+
+  async function handleGenerate() {
+    if (!canGenerate) {
+      return;
+    }
+
+    setIsGenerating(true);
+    setErrorMessage(null);
+
+    try {
+      const nextResults = await onGenerate();
+      setResults(nextResults);
+    } catch {
+      setErrorMessage("発話プレビューの生成に失敗しました。");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div className="subpanel">
+      <div className="summary-card__header">
+        <h3>発話プレビュー</h3>
+        <span className="summary-chip summary-chip--notable">mock / template</span>
+      </div>
+      <p className="summary-note">
+        実LLMを呼ばず、現在の注目個体から mock / template の発話だけを確認します。
+      </p>
+      <button
+        className="button button--ghost"
+        disabled={!canGenerate}
+        type="button"
+        onClick={handleGenerate}
+      >
+        {isGenerating ? "生成中" : "発話プレビューを生成"}
+      </button>
+
+      {!focusedCharacter ? <p>注目個体を選ぶと発話を確認できます。</p> : null}
+
+      {errorMessage ? <p className="summary-note">{errorMessage}</p> : null}
+
+      {results.length > 0 ? (
+        <div className="stack">
+          {results.map((result) => (
+            <div key={result.providerLabel} className="summary-card">
+              <strong>{result.providerLabel}</strong>
+              {result.status === "ok" ? (
+                <p>{result.text}</p>
+              ) : (
+                <p className="summary-note">{result.reason ?? "発話なし"}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/presentation/utterance/buildUtterancePreviewRequest.test.ts
+++ b/src/presentation/utterance/buildUtterancePreviewRequest.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { Character, EventSummary, JudgementResult } from "../../domain/types";
+import { buildUtterancePreviewRequest } from "./buildUtterancePreviewRequest";
+
+const character: Character = {
+  id: "ren",
+  name: "Ren",
+  bloodlineId: "fox",
+  bloodlineName: "狐火",
+  age: 17,
+  lifespanRemaining: 2,
+  role: "Support",
+  element: "Water",
+  yinYang: "Balanced",
+  alive: true,
+  favorite: false,
+  blessings: 1,
+  trials: 2,
+  deathReason: null,
+  notable: ["夜明けに小さな兆しを見た。", "試練の気配に気づいた。"],
+  milestoneHistory: [],
+  warningIssued: false,
+  position: { x: 0, z: 0 },
+};
+
+const warningSummary: EventSummary = {
+  layer: "intervention",
+  trigger: "warning",
+  title: "終わりの兆し",
+  description: "Ren の寿命が尽きかけている。",
+  targetCharacterName: "Ren",
+  tick: 12,
+};
+
+describe("buildUtterancePreviewRequest", () => {
+  it("builds a provider-neutral warning request from focused character and latest event", () => {
+    const request = buildUtterancePreviewRequest({
+      character,
+      latestEventSummary: warningSummary,
+      latestJudgement: null,
+      tick: 12,
+    });
+
+    expect(request).toMatchObject({
+      requestId: "limited-ui-12-ren",
+      character: {
+        id: "ren",
+        name: "Ren",
+        growthSummary: "notable 2 件",
+      },
+      situation: {
+        eventKind: "warning",
+        eventSummary: "Ren の寿命が尽きかけている。",
+        worldSummary: "tick 12 の箱庭状態",
+      },
+      constraints: {
+        maxLength: 80,
+        language: "ja",
+        mode: "safe",
+      },
+    });
+  });
+
+  it("uses the latest judgement action for Bless/Test preview context", () => {
+    const latestJudgement: JudgementResult = {
+      action: "test",
+      targetCharacterName: "Ren",
+      formula: "1d20 + 1",
+      roll: 15,
+      modifier: 1,
+      total: 16,
+      rank: "success",
+      effect: "試練を越えて勢いを得た。",
+      sideEffect: null,
+      changes: [{ label: "Momentum", before: 0, after: 1 }],
+      tick: 13,
+    };
+
+    const request = buildUtterancePreviewRequest({
+      character,
+      latestEventSummary: warningSummary,
+      latestJudgement,
+      tick: 13,
+    });
+
+    expect(request.situation.eventKind).toBe("test");
+    expect(request.situation.eventSummary).toContain("Test 結果");
+    expect(request.situation.eventSummary).toContain("試練を越えて勢いを得た。");
+  });
+});

--- a/src/presentation/utterance/buildUtterancePreviewRequest.ts
+++ b/src/presentation/utterance/buildUtterancePreviewRequest.ts
@@ -1,0 +1,69 @@
+import type { UtteranceEventKind, UtteranceRequest } from "../../application/utterance/types";
+import type { Character, EventSummary, JudgementResult } from "../../domain/types";
+
+interface BuildUtterancePreviewRequestInput {
+  character: Character;
+  latestEventSummary: EventSummary | null;
+  latestJudgement: JudgementResult | null;
+  tick: number;
+}
+
+function mapEventKind(
+  latestEventSummary: EventSummary | null,
+  latestJudgement: JudgementResult | null,
+): UtteranceEventKind {
+  if (latestJudgement) {
+    return latestJudgement.action;
+  }
+
+  switch (latestEventSummary?.trigger) {
+    case "manual":
+      return "manual";
+    case "routine":
+      return "routine";
+    case "warning":
+      return "warning";
+    default:
+      return "unknown";
+  }
+}
+
+function buildStatusSummary(character: Character) {
+  if (!character.alive) {
+    return character.deathReason ? `死亡: ${character.deathReason}` : "死亡";
+  }
+
+  return `年齢 ${character.age} / 残寿命 ${character.lifespanRemaining} / 加護 ${character.blessings} / 試練 ${character.trials}`;
+}
+
+export function buildUtterancePreviewRequest({
+  character,
+  latestEventSummary,
+  latestJudgement,
+  tick,
+}: BuildUtterancePreviewRequestInput): UtteranceRequest {
+  const eventSummary = latestJudgement
+    ? `${latestJudgement.targetCharacterName} への ${latestJudgement.action === "bless" ? "Bless" : "Test"} 結果: ${latestJudgement.effect}`
+    : latestEventSummary?.description;
+
+  return {
+    requestId: `limited-ui-${tick}-${character.id}`,
+    character: {
+      id: character.id,
+      name: character.name,
+      faithSummary: "信仰度の詳細値はまだ UI 連携していないため、現在は箱庭の観察状態だけを渡す。",
+      growthSummary: `notable ${character.notable.length} 件`,
+      statusSummary: buildStatusSummary(character),
+    },
+    situation: {
+      eventKind: mapEventKind(latestEventSummary, latestJudgement),
+      eventSummary,
+      worldSummary: `tick ${tick} の箱庭状態`,
+    },
+    constraints: {
+      maxLength: 80,
+      language: "ja",
+      mode: "safe",
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Closes #51

- `mockProvider` / `templateProvider` の発話を、実LLMなしで確認できる最小UIを追加しました。
- `AppShell` を composition root 相当として、concrete provider をここで固定配線しました。
- Presentation 側に provider-neutral request builder と表示パネルを追加しました。

## Scope
PBI-LLM-LIMITED-UI-001 のみです。

## 変更ファイル
- `src/app/AppShell.tsx`
- `src/presentation/utterance/UtterancePreviewPanel.tsx`
- `src/presentation/utterance/buildUtterancePreviewRequest.ts`
- `src/presentation/utterance/buildUtterancePreviewRequest.test.ts`

## 今回やらないこと
- 実LLM接続
- OpenAI / Anthropic 接続
- HTTP通信
- API key / secret 保存
- provider設定UI
- free / demo provider の自動fallback
- Character Passport統合
- server / package / CI 変更

## レーン分離
- Character Passport / tactics の Domain / Application には触れていません。
- `src/domain/**`、`src/application/passport/**`、`src/application/tactics/**` は未変更です。
- `server/**`、`package.json`、`.github/**` も未変更です。

## Checks
- `npx tsc --noEmit`
- `npx vitest run src/presentation/utterance/buildUtterancePreviewRequest.test.ts src/infrastructure/llm/utteranceProviders.test.ts`
- `npm run test:domain`
- `npm run build`
- dev smoke: login → sandbox → 発話プレビュー生成 → `mockProvider` / `templateProvider` 表示確認

## Notes
- sandbox 内では Vite / Vitest の esbuild 子プロセス起動が `EPERM` になったため、該当検証は権限付きで再実行して成功を確認しています。
- ブラウザ console の local app error は 0 件でした。GitHub tab 由来の既存 error は本PRとは無関係です。