### PR TITLE
Character Passport export contract のdriftをsmokeで防ぐ

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -128,6 +128,21 @@ Application source snapshot / Domain draft
 
 `Character Passport JSON` は export contract であり、内部会話モデルではありません。
 
+## drift 防止
+
+`server/character-passport.mjs` は `PASSPORT_EXPORT_CONTRACT` を公開し、server 側で使う export 契約のローカル定義を一箇所に集約します。
+`npm run passport:smoke` は smoke 専用の `server/passport-contract-smoke.mjs` を読み込み、TypeScript AST 経由で `src/domain/passport/**` の canonical 定義と照合します。
+
+これにより、次の定義が Domain と server export adapter でズレた場合は smoke が失敗します。
+
+- `schemaVersion`
+- `fivePhaseElements`
+- `combatClasses`
+- `combatClassByElement`
+- `baseAttributes`
+- Faith 関連 enum
+- `growthCategories`
+
 ## 何ができるか
 
 - Character Passport v1 の export JSON を組み立てる
@@ -139,6 +154,7 @@ Application source snapshot / Domain draft
 
 | 関数 | 説明 |
 |---|---|
+| `PASSPORT_EXPORT_CONTRACT` | server export adapter が参照する契約スナップショット |
 | `createCharacterPassportV1(input)` | Domain 寄りの draft から Character Passport v1 export JSON を組み立てる |
 | `adaptCharacterPassportSourceToExport(source)` | Application source snapshot を export JSON へ変換する adapter |
 | `writeCharacterPassportFile(passport)` | Passport JSON をローカルファイルへ保存する |
@@ -263,6 +279,7 @@ npm run passport:smoke
 3. `schemaVersion` が `character-passport/v1` になっている
 4. `element` と `combatClass` の固定対応違反を拒否できる
 5. `characterId` の path traversal / slash を拒否できる
+6. Domain canonical 定義と server export contract が drift していない
 
 ## 今回まだ含まないもの
 

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -5,22 +5,32 @@ import { initDirs } from './local-game-data.mjs';
 
 const DATA_ROOT = resolve(process.cwd(), 'god-sandbox-data');
 const PASSPORT_DIR = join(DATA_ROOT, 'exports', 'character-passports');
-const SCHEMA_VERSION = 'character-passport/v1';
-const FIVE_PHASE_KEYS = ['wood', 'fire', 'earth', 'metal', 'water'];
-const BASE_ATTRIBUTE_KEYS = ['vision', 'power', 'guard', 'discipline', 'flow'];
-const VALID_ELEMENTS = new Set(FIVE_PHASE_KEYS);
-const VALID_CLASSES = new Set(['ranger', 'mage', 'guardian', 'knight', 'healer']);
-const VALID_OBEDIENCE_BIASES = new Set(['cautious', 'fervent', 'stable', 'disciplined', 'adaptive']);
-const VALID_COMMAND_INTERPRETATIONS = new Set(['skeptical', 'measured', 'literal', 'contextual']);
-const VALID_HAZARD_RESPONSES = new Set(['avoidant', 'guarded', 'resolute']);
-const VALID_AUTONOMY_ALIGNMENTS = new Set(['selfDirected', 'balanced', 'deferential']);
-const COMBAT_CLASS_BY_ELEMENT = {
-  wood: 'ranger',
-  fire: 'mage',
-  earth: 'guardian',
-  metal: 'knight',
-  water: 'healer',
-};
+export const PASSPORT_EXPORT_CONTRACT = Object.freeze({
+  schemaVersion: 'character-passport/v1',
+  fivePhaseElements: ['wood', 'fire', 'earth', 'metal', 'water'],
+  combatClasses: ['ranger', 'mage', 'guardian', 'knight', 'healer'],
+  combatClassByElement: {
+    wood: 'ranger',
+    fire: 'mage',
+    earth: 'guardian',
+    metal: 'knight',
+    water: 'healer',
+  },
+  baseAttributes: ['vision', 'power', 'guard', 'discipline', 'flow'],
+  faithObedienceBiases: ['cautious', 'fervent', 'stable', 'disciplined', 'adaptive'],
+  faithCommandInterpretations: ['skeptical', 'measured', 'literal', 'contextual'],
+  faithHazardResponses: ['avoidant', 'guarded', 'resolute'],
+  faithAutonomyAlignments: ['selfDirected', 'balanced', 'deferential'],
+  faithTrustBands: ['dismissive', 'wary', 'steady', 'trusting', 'devoted'],
+  growthCategories: ['blessings', 'trials', 'chaosExposure'],
+});
+
+const VALID_ELEMENTS = new Set(PASSPORT_EXPORT_CONTRACT.fivePhaseElements);
+const VALID_CLASSES = new Set(PASSPORT_EXPORT_CONTRACT.combatClasses);
+const VALID_OBEDIENCE_BIASES = new Set(PASSPORT_EXPORT_CONTRACT.faithObedienceBiases);
+const VALID_COMMAND_INTERPRETATIONS = new Set(PASSPORT_EXPORT_CONTRACT.faithCommandInterpretations);
+const VALID_HAZARD_RESPONSES = new Set(PASSPORT_EXPORT_CONTRACT.faithHazardResponses);
+const VALID_AUTONOMY_ALIGNMENTS = new Set(PASSPORT_EXPORT_CONTRACT.faithAutonomyAlignments);
 
 function assertSafeName(name, label) {
   if (!name || typeof name !== 'string') {
@@ -92,7 +102,7 @@ function getFaithTrustBand(value) {
 function assertFivePhaseValueMap(record, label) {
   assertPlainObject(record, label);
 
-  for (const key of FIVE_PHASE_KEYS) {
+  for (const key of PASSPORT_EXPORT_CONTRACT.fivePhaseElements) {
     assertFiniteNumber(record[key], `${label}.${key}`);
   }
 }
@@ -100,7 +110,7 @@ function assertFivePhaseValueMap(record, label) {
 function normalizeBaseAttributes(baseAttributes) {
   assertPlainObject(baseAttributes, 'baseAttributes');
 
-  for (const key of BASE_ATTRIBUTE_KEYS) {
+  for (const key of PASSPORT_EXPORT_CONTRACT.baseAttributes) {
     assertFiniteNumber(baseAttributes[key], `baseAttributes.${key}`);
   }
 
@@ -184,7 +194,7 @@ function normalizeAbilities(abilities) {
 }
 
 function assertCombatClassMatchesElement(element, combatClass) {
-  const expectedCombatClass = COMBAT_CLASS_BY_ELEMENT[element];
+  const expectedCombatClass = PASSPORT_EXPORT_CONTRACT.combatClassByElement[element];
 
   if (combatClass !== expectedCombatClass) {
     throw new Error(
@@ -204,7 +214,7 @@ export function createCharacterPassportV1(input) {
   assertCombatClassMatchesElement(input.element, input.combatClass);
 
   return {
-    schemaVersion: SCHEMA_VERSION,
+    schemaVersion: PASSPORT_EXPORT_CONTRACT.schemaVersion,
     characterId: input.characterId,
     name: input.name,
     originGame: 'god-sandbox-mvp',
@@ -224,7 +234,7 @@ export function adaptCharacterPassportSourceToExport(source) {
 }
 
 export async function writeCharacterPassportFile(passport) {
-  if (passport.schemaVersion !== SCHEMA_VERSION) {
+  if (passport.schemaVersion !== PASSPORT_EXPORT_CONTRACT.schemaVersion) {
     throw new Error(`Unexpected schemaVersion: ${passport.schemaVersion}`);
   }
   assertSafeName(passport.characterId, 'characterId');
@@ -325,14 +335,67 @@ function sampleRenPassportSource() {
   };
 }
 
+function assertSameKeys(record, expectedKeys, label) {
+  const actualKeys = Object.keys(record);
+  const expectedJson = JSON.stringify(expectedKeys);
+  const actualJson = JSON.stringify(actualKeys);
+
+  if (actualJson !== expectedJson) {
+    throw new Error(`Unexpected ${label} keys: expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+function assertExportJsonMatchesContract(saved) {
+  if ('attributes' in saved || 'history' in saved) {
+    throw new Error('Legacy attributes/history fields must not be preserved in Character Passport v1 export.');
+  }
+
+  if (saved.combatClass === 'rogue') {
+    throw new Error('Legacy rogue combatClass must not be preserved in Character Passport v1 export.');
+  }
+
+  assertSameKeys(saved.baseAttributes, PASSPORT_EXPORT_CONTRACT.baseAttributes, 'baseAttributes');
+  assertSameKeys(saved.faith.sources, PASSPORT_EXPORT_CONTRACT.growthCategories, 'faith.sources');
+  assertSameKeys(saved.growth, PASSPORT_EXPORT_CONTRACT.growthCategories, 'growth');
+
+  for (const category of PASSPORT_EXPORT_CONTRACT.growthCategories) {
+    assertSameKeys(saved.growth[category], PASSPORT_EXPORT_CONTRACT.fivePhaseElements, `growth.${category}`);
+  }
+
+  for (const key of ['value', 'obedienceBias', 'commandInterpretation', 'hazardResponse', 'autonomyAlignment', 'trustBand']) {
+    if (!(key in saved.faith)) {
+      throw new Error(`Missing faith.${key} in Character Passport v1 export.`);
+    }
+  }
+
+  if (!PASSPORT_EXPORT_CONTRACT.faithTrustBands.includes(saved.faith.trustBand)) {
+    throw new Error(`Unexpected faith.trustBand: ${saved.faith.trustBand}`);
+  }
+
+  if (!Array.isArray(saved.skills) || !Array.isArray(saved.abilities)) {
+    throw new Error('skills and abilities must be separate arrays.');
+  }
+
+  if (saved.skills.some((skill) => skill.kind !== 'skill')) {
+    throw new Error('skills must contain skill entries only.');
+  }
+
+  if (saved.abilities.some((ability) => ability.kind !== 'ability')) {
+    throw new Error('abilities must contain ability entries only.');
+  }
+}
+
 if (process.argv[2] === 'smoke') {
   console.log('passport:smoke start');
 
   const passport = adaptCharacterPassportSourceToExport(sampleRenPassportSource());
   const filePath = await writeCharacterPassportFile(passport);
   const saved = JSON.parse(await readFile(filePath, 'utf-8'));
+  const { assertPassportExportContractMatchesDomain } = await import('./passport-contract-smoke.mjs');
 
-  if (saved.schemaVersion !== SCHEMA_VERSION) {
+  await assertPassportExportContractMatchesDomain(PASSPORT_EXPORT_CONTRACT);
+
+  if (saved.schemaVersion !== PASSPORT_EXPORT_CONTRACT.schemaVersion) {
     throw new Error(`Unexpected schemaVersion: ${saved.schemaVersion}`);
   }
 
@@ -347,6 +410,8 @@ if (process.argv[2] === 'smoke') {
   if (saved.skills.length !== 1 || saved.abilities.length !== 1) {
     throw new Error('Expected one skill and one ability in the exported sample.');
   }
+
+  assertExportJsonMatchesContract(saved);
 
   console.log('passport file:', filePath);
   console.log('passport schema ok:', saved.schemaVersion);

--- a/server/passport-contract-smoke.mjs
+++ b/server/passport-contract-smoke.mjs
@@ -1,0 +1,185 @@
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+
+function fail(message) {
+  throw new Error(`Passport export contract drift: ${message}`);
+}
+
+function isExportedConst(statement, name, ts) {
+  if (!ts.isVariableStatement(statement)) {
+    return false;
+  }
+
+  const isExported = statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+  if (!isExported) {
+    return false;
+  }
+
+  return statement.declarationList.declarations.some(
+    (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === name,
+  );
+}
+
+function unwrapExpression(expression, ts) {
+  let current = expression;
+
+  while (current && (ts.isAsExpression(current) || ts.isSatisfiesExpression(current))) {
+    current = current.expression;
+  }
+
+  return current;
+}
+
+function readStringLiteral(expression, label, ts) {
+  const current = unwrapExpression(expression, ts);
+
+  if (!current || !ts.isStringLiteral(current)) {
+    fail(`${label} must be a string literal`);
+  }
+
+  return current.text;
+}
+
+function readStringArray(expression, label, ts) {
+  const current = unwrapExpression(expression, ts);
+
+  if (!current || !ts.isArrayLiteralExpression(current)) {
+    fail(`${label} must be an array literal`);
+  }
+
+  return current.elements.map((element, index) => readStringLiteral(element, `${label}[${index}]`, ts));
+}
+
+function readStringRecord(expression, label, ts) {
+  const current = unwrapExpression(expression, ts);
+
+  if (!current || !ts.isObjectLiteralExpression(current)) {
+    fail(`${label} must be an object literal`);
+  }
+
+  const record = {};
+
+  for (const property of current.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      fail(`${label} must contain only property assignments`);
+    }
+
+    const propertyName = property.name;
+    const key = ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName) ? propertyName.text : null;
+    if (!key) {
+      fail(`${label} contains an unsupported property name`);
+    }
+
+    record[key] = readStringLiteral(property.initializer, `${label}.${key}`, ts);
+  }
+
+  return record;
+}
+
+async function parseSource(relativePath, ts) {
+  const filePath = resolve(process.cwd(), relativePath);
+  const text = await readFile(filePath, 'utf-8');
+
+  return ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function findExportedConst(sourceFile, name, ts) {
+  for (const statement of sourceFile.statements) {
+    if (!isExportedConst(statement, name, ts)) {
+      continue;
+    }
+
+    const declaration = statement.declarationList.declarations.find(
+      (entry) => ts.isIdentifier(entry.name) && entry.name.text === name,
+    );
+
+    if (!declaration?.initializer) {
+      fail(`${name} must have an initializer`);
+    }
+
+    return declaration.initializer;
+  }
+
+  fail(`${name} was not found`);
+}
+
+function assertSameJson(actual, expected, label) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+
+  if (actualJson !== expectedJson) {
+    fail(`${label} differs. server=${actualJson} domain=${expectedJson}`);
+  }
+}
+
+export async function assertPassportExportContractMatchesDomain(contract) {
+  const ts = await import('typescript');
+  const fivePhases = await parseSource('src/domain/passport/fivePhases.ts', ts);
+  const faith = await parseSource('src/domain/passport/faith.ts', ts);
+  const growth = await parseSource('src/domain/passport/growth.ts', ts);
+  const characterPassport = await parseSource('src/domain/passport/characterPassport.ts', ts);
+
+  assertSameJson(
+    contract.schemaVersion,
+    readStringLiteral(
+      findExportedConst(characterPassport, 'CHARACTER_PASSPORT_SCHEMA_VERSION', ts),
+      'CHARACTER_PASSPORT_SCHEMA_VERSION',
+      ts,
+    ),
+    'schemaVersion',
+  );
+  assertSameJson(
+    contract.fivePhaseElements,
+    readStringArray(findExportedConst(fivePhases, 'FIVE_PHASE_ELEMENTS', ts), 'FIVE_PHASE_ELEMENTS', ts),
+    'fivePhaseElements',
+  );
+  assertSameJson(
+    contract.combatClasses,
+    readStringArray(findExportedConst(fivePhases, 'COMBAT_CLASSES', ts), 'COMBAT_CLASSES', ts),
+    'combatClasses',
+  );
+  assertSameJson(
+    contract.combatClassByElement,
+    readStringRecord(findExportedConst(fivePhases, 'COMBAT_CLASS_BY_ELEMENT', ts), 'COMBAT_CLASS_BY_ELEMENT', ts),
+    'combatClassByElement',
+  );
+  assertSameJson(
+    contract.baseAttributes,
+    readStringArray(findExportedConst(fivePhases, 'BASIC_ATTRIBUTES', ts), 'BASIC_ATTRIBUTES', ts),
+    'baseAttributes',
+  );
+  assertSameJson(
+    contract.faithObedienceBiases,
+    readStringArray(findExportedConst(faith, 'FAITH_OBEDIENCE_BIASES', ts), 'FAITH_OBEDIENCE_BIASES', ts),
+    'faithObedienceBiases',
+  );
+  assertSameJson(
+    contract.faithCommandInterpretations,
+    readStringArray(
+      findExportedConst(faith, 'FAITH_COMMAND_INTERPRETATIONS', ts),
+      'FAITH_COMMAND_INTERPRETATIONS',
+      ts,
+    ),
+    'faithCommandInterpretations',
+  );
+  assertSameJson(
+    contract.faithHazardResponses,
+    readStringArray(findExportedConst(faith, 'FAITH_HAZARD_RESPONSES', ts), 'FAITH_HAZARD_RESPONSES', ts),
+    'faithHazardResponses',
+  );
+  assertSameJson(
+    contract.faithAutonomyAlignments,
+    readStringArray(findExportedConst(faith, 'FAITH_AUTONOMY_ALIGNMENTS', ts), 'FAITH_AUTONOMY_ALIGNMENTS', ts),
+    'faithAutonomyAlignments',
+  );
+  assertSameJson(
+    contract.faithTrustBands,
+    readStringArray(findExportedConst(faith, 'FAITH_TRUST_BANDS', ts), 'FAITH_TRUST_BANDS', ts),
+    'faithTrustBands',
+  );
+  assertSameJson(
+    contract.growthCategories,
+    readStringArray(findExportedConst(growth, 'GROWTH_CATEGORIES', ts), 'GROWTH_CATEGORIES', ts),
+    'growthCategories',
+  );
+}


### PR DESCRIPTION
Closes #54

## 概要
- Character Passport export adapter のローカル契約を `PASSPORT_EXPORT_CONTRACT` に集約
- `npm run passport:smoke` で Domain canonical 定義と server export contract を照合する smoke 専用 contract check を追加
- export JSON の主要契約として、`element` / `combatClass` 固定対応、`baseAttributes` キー、Faith 主要フィールド、`growth`、`skills` / `abilities` 分離、旧 `attributes` / `history` / `rogue` 非延命、`characterId` path traversal 防止を確認
- `server/README.md` に drift 防止方針を追記

## 変更ファイル
- `server/character-passport.mjs`
- `server/passport-contract-smoke.mjs`
- `server/README.md`

## 採用方針
shared contract import は今回は採用していません。

理由:
- server は `.mjs`、Domain canonical は `src/domain/passport/*.ts` で、自然な直接 import には TypeScript / ESM / Node 実行境界の整理が必要
- package変更や build 設定変更に踏み込まず、小さく検知可能性を上げる方針がこのPBIに合うため

代わりに、smoke 時だけ TypeScript AST で Domain canonical const を読み、server の `PASSPORT_EXPORT_CONTRACT` と比較する contract test に留めました。通常の server export 実行時には Domain TS を読みません。

## 今回やらないこと
- REST API 拡張
- file storage 大改修
- UI表示
- tactics battle logic
- LLM発話統合
- Character Passport の内部会話モデル化
- provider設定UI
- 実LLM接続
- package変更
- CI workflow変更

## レーンBとの独立性
- `src/application/utterance/**` は未変更
- `src/infrastructure/llm/**` は未変更
- `src/presentation/**` は未変更
- frontend UI は未変更

## 確認
- `npm run passport:smoke`
- `npm run build`
- `npm run test:domain`