### PR TITLE
Domain model から属性の支配ルールを外す

### DIFF
--- a/src/domain/passport/characterPassport.test.ts
+++ b/src/domain/passport/characterPassport.test.ts
@@ -2,13 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { createCharacterPassportV1 } from "./characterPassport";
 import { createEmptyGrowth, createGrowthSourceTotals } from "./growth";
-import {
-  BUFF_BY_ELEMENT,
-  COMBAT_CLASS_BY_ELEMENT,
-  DEBUFF_BY_ELEMENT,
-  STATUS_CONDITION_BY_ELEMENT,
-  createBaseAttributes,
-} from "./fivePhases";
+import { createBaseAttributes } from "./fivePhases";
 
 function buildPassport() {
   return createCharacterPassportV1({
@@ -83,14 +77,6 @@ function buildPassport() {
 }
 
 describe("character passport domain", () => {
-  it("keeps five-phase mappings aligned across class, status, buff, and debuff", () => {
-    expect(COMBAT_CLASS_BY_ELEMENT.wood).toBe("ranger");
-    expect(COMBAT_CLASS_BY_ELEMENT.water).toBe("healer");
-    expect(STATUS_CONDITION_BY_ELEMENT.metal).toBe("sealed");
-    expect(BUFF_BY_ELEMENT.earth).toBe("fortify");
-    expect(DEBUFF_BY_ELEMENT.fire).toBe("overheated");
-  });
-
   it("models faith as command interpretation rather than a raw success chance", () => {
     const passport = buildPassport();
 
@@ -101,14 +87,37 @@ describe("character passport domain", () => {
     expect(passport.faith.autonomyAlignment).toBe("balanced");
   });
 
-  it("rejects an element and combat class mismatch", () => {
-    expect(() =>
-      createCharacterPassportV1({
-        ...buildPassport(),
-        element: "wood",
-        combatClass: "mage",
+  it("keeps element and combatClass as independent passport values", () => {
+    const passport = createCharacterPassportV1({
+      ...buildPassport(),
+      element: "wood",
+      combatClass: "mage",
+      baseAttributes: createBaseAttributes({
+        vision: 1,
+        power: 8,
+        guard: 2,
+        discipline: 3,
+        flow: 4,
       }),
-    ).toThrow(/Combat class mismatch/);
+      skills: [
+        {
+          ...buildPassport().skills[0],
+          element: "fire",
+        },
+      ],
+      abilities: [
+        {
+          ...buildPassport().abilities[0],
+          element: "water",
+        },
+      ],
+    });
+
+    expect(passport.element).toBe("wood");
+    expect(passport.combatClass).toBe("mage");
+    expect(passport.baseAttributes.power).toBe(8);
+    expect(passport.skills[0]?.element).toBe("fire");
+    expect(passport.abilities[0]?.element).toBe("water");
   });
 
   it("keeps skills and abilities as distinct boundaries in the passport", () => {

--- a/src/domain/passport/characterPassport.ts
+++ b/src/domain/passport/characterPassport.ts
@@ -1,11 +1,6 @@
 import { createFaith, type Faith, type FaithDraft } from "./faith";
 import { cloneGrowth, type CharacterGrowth } from "./growth";
-import {
-  getCombatClassForElement,
-  type BasicAttributeSet,
-  type CombatClass,
-  type FivePhaseElement,
-} from "./fivePhases";
+import type { BasicAttributeSet, CombatClass, FivePhaseElement } from "./fivePhases";
 import type { AbilityDefinition, SkillDefinition } from "./skill";
 
 export const CHARACTER_PASSPORT_SCHEMA_VERSION = "character-passport/v1";
@@ -39,14 +34,6 @@ export interface CharacterPassportV1 {
 }
 
 export function createCharacterPassportV1(draft: CharacterPassportDraft): CharacterPassportV1 {
-  const expectedCombatClass = getCombatClassForElement(draft.element);
-
-  if (draft.combatClass !== expectedCombatClass) {
-    throw new Error(
-      `Combat class mismatch for ${draft.element}: expected ${expectedCombatClass}, received ${draft.combatClass}.`,
-    );
-  }
-
   return {
     schemaVersion: CHARACTER_PASSPORT_SCHEMA_VERSION,
     characterId: draft.characterId,

--- a/src/domain/passport/fivePhases.ts
+++ b/src/domain/passport/fivePhases.ts
@@ -4,92 +4,20 @@ export type FivePhaseElement = (typeof FIVE_PHASE_ELEMENTS)[number];
 export const COMBAT_CLASSES = ["ranger", "mage", "guardian", "knight", "healer"] as const;
 export type CombatClass = (typeof COMBAT_CLASSES)[number];
 
-export const COMBAT_CLASS_BY_ELEMENT = {
-  wood: "ranger",
-  fire: "mage",
-  earth: "guardian",
-  metal: "knight",
-  water: "healer",
-} as const satisfies Record<FivePhaseElement, CombatClass>;
-
-export const ELEMENT_BY_COMBAT_CLASS = {
-  ranger: "wood",
-  mage: "fire",
-  guardian: "earth",
-  knight: "metal",
-  healer: "water",
-} as const satisfies Record<CombatClass, FivePhaseElement>;
-
 export const BASIC_ATTRIBUTES = ["vision", "power", "guard", "discipline", "flow"] as const;
 export type BasicAttribute = (typeof BASIC_ATTRIBUTES)[number];
-
-export const BASIC_ATTRIBUTE_BY_ELEMENT = {
-  wood: "vision",
-  fire: "power",
-  earth: "guard",
-  metal: "discipline",
-  water: "flow",
-} as const satisfies Record<FivePhaseElement, BasicAttribute>;
 
 export const STATUS_CONDITIONS = ["rooted", "burning", "burdened", "sealed", "chilled"] as const;
 export type StatusCondition = (typeof STATUS_CONDITIONS)[number];
 
-export const STATUS_CONDITION_BY_ELEMENT = {
-  wood: "rooted",
-  fire: "burning",
-  earth: "burdened",
-  metal: "sealed",
-  water: "chilled",
-} as const satisfies Record<FivePhaseElement, StatusCondition>;
-
 export const BUFFS = ["growth", "ignite", "fortify", "focus", "flowing"] as const;
 export type TacticsBuff = (typeof BUFFS)[number];
-
-export const BUFF_BY_ELEMENT = {
-  wood: "growth",
-  fire: "ignite",
-  earth: "fortify",
-  metal: "focus",
-  water: "flowing",
-} as const satisfies Record<FivePhaseElement, TacticsBuff>;
 
 export const DEBUFFS = ["entangled", "overheated", "crumbled", "fractured", "displaced"] as const;
 export type TacticsDebuff = (typeof DEBUFFS)[number];
 
-export const DEBUFF_BY_ELEMENT = {
-  wood: "entangled",
-  fire: "overheated",
-  earth: "crumbled",
-  metal: "fractured",
-  water: "displaced",
-} as const satisfies Record<FivePhaseElement, TacticsDebuff>;
-
 export type FivePhaseValueMap<T> = Record<FivePhaseElement, T>;
 export type BasicAttributeSet = Record<BasicAttribute, number>;
-
-export function getCombatClassForElement(element: FivePhaseElement): CombatClass {
-  return COMBAT_CLASS_BY_ELEMENT[element];
-}
-
-export function getElementForCombatClass(combatClass: CombatClass): FivePhaseElement {
-  return ELEMENT_BY_COMBAT_CLASS[combatClass];
-}
-
-export function getBasicAttributeForElement(element: FivePhaseElement): BasicAttribute {
-  return BASIC_ATTRIBUTE_BY_ELEMENT[element];
-}
-
-export function getStatusConditionForElement(element: FivePhaseElement): StatusCondition {
-  return STATUS_CONDITION_BY_ELEMENT[element];
-}
-
-export function getBuffForElement(element: FivePhaseElement): TacticsBuff {
-  return BUFF_BY_ELEMENT[element];
-}
-
-export function getDebuffForElement(element: FivePhaseElement): TacticsDebuff {
-  return DEBUFF_BY_ELEMENT[element];
-}
 
 export function createFivePhaseValues(values: Partial<FivePhaseValueMap<number>> = {}): FivePhaseValueMap<number> {
   return {


### PR DESCRIPTION

Closes #72

## 対象PBI

PBI-PASSPORT-DOMAIN-ATTRIBUTE-INDEPENDENCE-001

## 概要

Character Passport の属性独立方針に合わせて、Domain model から旧五行設計由来の支配ルールを外します。

このPRでは、`element` と `combatClass` を独立した値として扱い、Domain 側で `element / combatClass` mismatch を reject しないようにします。

## 変更ファイル

- src/domain/passport/fivePhases.ts
- src/domain/passport/characterPassport.ts
- src/domain/passport/characterPassport.test.ts

## 今回やったこと

- `createCharacterPassportV1()` から `element -> combatClass` mismatch reject を削除
- `COMBAT_CLASS_BY_ELEMENT` / `ELEMENT_BY_COMBAT_CLASS` を削除
- `BASIC_ATTRIBUTE_BY_ELEMENT` / `STATUS_CONDITION_BY_ELEMENT` / `BUFF_BY_ELEMENT` / `DEBUFF_BY_ELEMENT` を削除
- `getCombatClassForElement()` など `get*ForElement` の支配ルール関数を削除
- テストを「mapping整合」から「element と combatClass は独立値として保持される」観点へ更新
- Skill / Ability の `element` も Passport 本体の `element` に支配されないことをテストで確認

## 外した支配ルール

- `element` が `combatClass` を自動決定するルール
- `combatClass` から `element` を逆引きするルール
- `element` が基本ステータスを決めるルール
- `element` が状態異常を決めるルール
- `element` がバフを決めるルール
- `element` がデバフを決めるルール

## 残した互換要素

- schema breaking change は行わず、wire format 上の `element` key は維持
- `wood / fire / earth / metal / water` は既存互換の属性値として維持
- `combatClass` の有限値 `ranger / mage / guardian / knight / healer` は維持
- `baseAttributes`、`StatusCondition`、`TacticsBuff`、`TacticsDebuff` の有限値一覧は維持

## 今回やらないこと

- server export 修正
- server README 修正
- smoke script 修正
- sample JSON 修正
- docs修正
- schema breaking change
- `element` key から `attribute` key への変更
- 2D / 3D asset contract
- 汎用パラメータ種類と数の確定
- package変更
- CI workflow変更

## レーンBとの分離

このPRは `src/domain/passport/**` のみを変更します。
server/**、samples/**、docs/** は変更していないため、レーンBの server export 追従作業とは変更ファイルが分かれています。

## 確認結果

- `npx vitest run src/domain/passport/characterPassport.test.ts`: OK
- `npm run test:domain`: OK
- `npm run build`: OK
- `git diff --cached --check`: OK

## 監査観点

- `element -> combatClass` 自動決定が Domain rule から外れていること
- `element / combatClass` mismatch reject が Domain 側から外れていること
- `*_BY_ELEMENT` と `get*ForElement` が Domain core rule として残っていないこと
- server/**、samples/**、docs/**、package、CI workflow を変更していないこと
