### PR TITLE
server: Passport exportを属性独立方針へ追従する

### DIFF
--- a/samples/creator-workflow/README.md
+++ b/samples/creator-workflow/README.md
@@ -10,14 +10,14 @@ GodSandbox を「キャラを作る -> 発話を見る -> 成長情報を確認�
 - `utterance-request.mock-template.json`: mock / template 発話へ渡す provider-neutral request
 - `utterance-response.mock.json`: mock 発話の期待例
 - `utterance-response.template.json`: template 発話の期待例
-- `character-passport.v1.json`: 外部ゲームやModが読む前提の Character Passport v1 JSON
+- `character-passport.v1.json`: 後続ゲームやPassport consumerが読む前提の Character Passport v1 JSON
 
 ## 確認手順
 
 1. `sample-character-source.json` で Ren の element / combatClass / Faith / Growth / Skill / Ability を見る。
 2. `utterance-request.mock-template.json` を見て、発話入力に secret や provider 固有設定が含まれないことを確認する。
 3. `utterance-response.mock.json` と `utterance-response.template.json` で、実LLMなしの発話例を見る。
-4. `character-passport.v1.json` を外部ゲームやModの読み取り対象として確認する。
+4. `character-passport.v1.json` を後続ゲームやPassport consumerの読み取り対象として確認する。
 5. 実際の server export smoke は `npm run passport:smoke` で確認する。
 
 ## 境界
@@ -25,3 +25,7 @@ GodSandbox を「キャラを作る -> 発話を見る -> 成長情報を確認�
 このサンプルは実LLM、BYOK / BYOM、provider設定UI、API key保存、外部ゲーム本体、battle logic を実装しません。
 
 Character Passport JSON は外部連携 contract であり、AI会話モデルの内部履歴ではありません。
+`element` は wire format 上の既存 key ですが、意味としては有限パラメータの1つである「属性」です。
+`element` は `combatClass` を自動決定しません。
+後続ゲームやPassport consumerは、必要なパラメータだけを読み、不要なパラメータはスキップできます。
+このサンプルの `element` と `combatClass` の組み合わせは固定契約ではなく、後続ゲーム側で自由に再解釈できます。

--- a/samples/creator-workflow/character-passport.v1.json
+++ b/samples/creator-workflow/character-passport.v1.json
@@ -4,7 +4,7 @@
   "name": "Ren",
   "originGame": "god-sandbox-mvp",
   "element": "metal",
-  "combatClass": "knight",
+  "combatClass": "mage",
   "baseAttributes": {
     "vision": 2,
     "power": 3,

--- a/samples/creator-workflow/sample-character-source.json
+++ b/samples/creator-workflow/sample-character-source.json
@@ -3,7 +3,7 @@
   "name": "Ren",
   "originGame": "god-sandbox-mvp",
   "element": "metal",
-  "combatClass": "knight",
+  "combatClass": "mage",
   "baseAttributes": {
     "vision": 2,
     "power": 3,

--- a/server/README.md
+++ b/server/README.md
@@ -138,7 +138,6 @@ Application source snapshot / Domain draft
 - `schemaVersion`
 - `fivePhaseElements`
 - `combatClasses`
-- `combatClassByElement`
 - `baseAttributes`
 - Faith 関連 enum
 - `growthCategories`
@@ -170,7 +169,7 @@ Application source snapshot / Domain draft
   "name": "Ren",
   "originGame": "god-sandbox-mvp",
   "element": "metal",
-  "combatClass": "knight",
+  "combatClass": "mage",
   "baseAttributes": {
     "vision": 2,
     "power": 3,
@@ -224,10 +223,11 @@ Application source snapshot / Domain draft
 以前の `server/character-passport.mjs` は、`attributes` / `history` / `rogue` などの server-only 仮スキーマを持っていました。
 PBI-PASSPORT-EXPORT-INTEGRATION-001 以降は、それを延命せず、Domain で確定した次の意味へ寄せます。
 
-- `element` と `combatClass` は 1:1 固定
+- `element` は wire format 上の既存 key だが、意味としては有限パラメータの1つである「属性」
+- `element` と `combatClass` は独立した値であり、server export は組み合わせを強制しない
 - `baseAttributes` は `vision / power / guard / discipline / flow`
 - `faith` は value だけでなく、命令解釈・危険命令への反応・自律判断寄りの項目を含む
-- `growth` は `blessings / trials / chaosExposure` を五行ごとに持つ
+- `growth` は `blessings / trials / chaosExposure` を持つ
 - `skills` は能動行動、`abilities` は受動 / 反応 / aura 効果
 
 ## `combatClass`
@@ -240,15 +240,9 @@ v1 では次の 5 種のみ許可します。
 - `knight`
 - `healer`
 
-対応は固定です。
-
-```text
-wood  = ranger
-fire  = mage
-earth = guardian
-metal = knight
-water = healer
-```
+`combatClass` は `element` から自動決定しません。
+後続ゲームは必要なパラメータだけ読み、不要なものはスキップできます。
+後続ゲームは、受け取った属性名や意味を自分のゲーム内で自由に再解釈できます。
 
 ## `characterId`
 
@@ -272,12 +266,12 @@ god-sandbox-data/
 npm run passport:smoke
 ```
 
-これで次の 5 点を確認できます。
+これで次の 6 点を確認できます。
 
 1. Domain 寄りの Passport export JSON が生成できる
 2. `god-sandbox-data/exports/character-passports/` に保存できる
 3. `schemaVersion` が `character-passport/v1` になっている
-4. `element` と `combatClass` の固定対応違反を拒否できる
+4. `element` と `combatClass` が独立した値として保存される
 5. `characterId` の path traversal / slash を拒否できる
 6. Domain canonical 定義と server export contract が drift していない
 

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -9,13 +9,6 @@ export const PASSPORT_EXPORT_CONTRACT = Object.freeze({
   schemaVersion: 'character-passport/v1',
   fivePhaseElements: ['wood', 'fire', 'earth', 'metal', 'water'],
   combatClasses: ['ranger', 'mage', 'guardian', 'knight', 'healer'],
-  combatClassByElement: {
-    wood: 'ranger',
-    fire: 'mage',
-    earth: 'guardian',
-    metal: 'knight',
-    water: 'healer',
-  },
   baseAttributes: ['vision', 'power', 'guard', 'discipline', 'flow'],
   faithObedienceBiases: ['cautious', 'fervent', 'stable', 'disciplined', 'adaptive'],
   faithCommandInterpretations: ['skeptical', 'measured', 'literal', 'contextual'],
@@ -193,16 +186,6 @@ function normalizeAbilities(abilities) {
   });
 }
 
-function assertCombatClassMatchesElement(element, combatClass) {
-  const expectedCombatClass = PASSPORT_EXPORT_CONTRACT.combatClassByElement[element];
-
-  if (combatClass !== expectedCombatClass) {
-    throw new Error(
-      `Combat class mismatch for ${element}: expected ${expectedCombatClass}, received ${combatClass}.`,
-    );
-  }
-}
-
 export function createCharacterPassportV1(input) {
   assertSafeName(input.characterId, 'characterId');
   assertNonEmptyString(input.name, 'name');
@@ -211,7 +194,6 @@ export function createCharacterPassportV1(input) {
   }
   assertEnum(input.element, VALID_ELEMENTS, 'element');
   assertEnum(input.combatClass, VALID_CLASSES, 'combatClass');
-  assertCombatClassMatchesElement(input.element, input.combatClass);
 
   return {
     schemaVersion: PASSPORT_EXPORT_CONTRACT.schemaVersion,
@@ -263,7 +245,7 @@ function sampleRenPassportSource() {
     name: 'Ren',
     originGame: 'god-sandbox-mvp',
     element: 'metal',
-    combatClass: 'knight',
+    combatClass: 'mage',
     baseAttributes: {
       vision: 2,
       power: 3,
@@ -399,8 +381,8 @@ if (process.argv[2] === 'smoke') {
     throw new Error(`Unexpected schemaVersion: ${saved.schemaVersion}`);
   }
 
-  if (saved.element !== 'metal' || saved.combatClass !== 'knight') {
-    throw new Error('Expected element/combatClass mapping to be preserved.');
+  if (saved.element !== 'metal' || saved.combatClass !== 'mage') {
+    throw new Error('Expected independent element/combatClass values to be preserved.');
   }
 
   if (saved.faith.trustBand !== 'steady') {
@@ -416,14 +398,7 @@ if (process.argv[2] === 'smoke') {
   console.log('passport file:', filePath);
   console.log('passport schema ok:', saved.schemaVersion);
   console.log('passport adapter ok:', `${saved.element}/${saved.combatClass}`);
-
-  try {
-    createCharacterPassportV1({ ...sampleRenPassportSource(), combatClass: 'mage' });
-    console.error('FAIL: should have rejected element/combatClass mismatch');
-    process.exit(1);
-  } catch (err) {
-    console.log('mapping mismatch rejected:', err.message);
-  }
+  console.log('element/combatClass independence preserved:', `${saved.element}/${saved.combatClass}`);
 
   try {
     await writeCharacterPassportFile({ ...passport, characterId: '../outside' });

--- a/server/passport-contract-smoke.mjs
+++ b/server/passport-contract-smoke.mjs
@@ -50,32 +50,6 @@ function readStringArray(expression, label, ts) {
   return current.elements.map((element, index) => readStringLiteral(element, `${label}[${index}]`, ts));
 }
 
-function readStringRecord(expression, label, ts) {
-  const current = unwrapExpression(expression, ts);
-
-  if (!current || !ts.isObjectLiteralExpression(current)) {
-    fail(`${label} must be an object literal`);
-  }
-
-  const record = {};
-
-  for (const property of current.properties) {
-    if (!ts.isPropertyAssignment(property)) {
-      fail(`${label} must contain only property assignments`);
-    }
-
-    const propertyName = property.name;
-    const key = ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName) ? propertyName.text : null;
-    if (!key) {
-      fail(`${label} contains an unsupported property name`);
-    }
-
-    record[key] = readStringLiteral(property.initializer, `${label}.${key}`, ts);
-  }
-
-  return record;
-}
-
 async function parseSource(relativePath, ts) {
   const filePath = resolve(process.cwd(), relativePath);
   const text = await readFile(filePath, 'utf-8');
@@ -137,11 +111,6 @@ export async function assertPassportExportContractMatchesDomain(contract) {
     contract.combatClasses,
     readStringArray(findExportedConst(fivePhases, 'COMBAT_CLASSES', ts), 'COMBAT_CLASSES', ts),
     'combatClasses',
-  );
-  assertSameJson(
-    contract.combatClassByElement,
-    readStringRecord(findExportedConst(fivePhases, 'COMBAT_CLASS_BY_ELEMENT', ts), 'COMBAT_CLASS_BY_ELEMENT', ts),
-    'combatClassByElement',
   );
   assertSameJson(
     contract.baseAttributes,


### PR DESCRIPTION
## 対象PBI
PBI-PASSPORT-EXPORT-ATTRIBUTE-INDEPENDENCE-001

Closes #74

## 変更ファイル
- `server/character-passport.mjs`
- `server/passport-contract-smoke.mjs`
- `server/README.md`
- `samples/creator-workflow/README.md`
- `samples/creator-workflow/sample-character-source.json`
- `samples/creator-workflow/character-passport.v1.json`

## 今回やったこと
- server export から `element / combatClass` mismatch reject を外しました。
- `PASSPORT_EXPORT_CONTRACT` から `combatClassByElement` を削除しました。
- `server/passport-contract-smoke.mjs` から `COMBAT_CLASS_BY_ELEMENT` のAST照合を外しました。
- smoke で `element` と `combatClass` が独立値として保存されることを確認する形に変更しました。
- READMEで、`element` は既存wire keyだが意味としては属性であり、`combatClass` を自動決定しないと説明しました。
- 後続ゲームは必要なパラメータだけ読み、不要なものはスキップできること、属性名や意味を自由に再解釈できることを説明しました。
- sample / fixture を `metal` + `mage` に更新し、旧五行対応が契約ではないことを見えるようにしました。

## PR #73との整合
- PR #73 では Domain core から `COMBAT_CLASS_BY_ELEMENT` などの支配ルールが削除されます。
- 本PRは server smoke が `COMBAT_CLASS_BY_ELEMENT` を探さないようにする追従PRです。
- PR #73 merge後も `npm run passport:smoke` が `COMBAT_CLASS_BY_ELEMENT` 欠落で壊れない形にしています。

## 今回やらないこと
- Domain model 修正
- `src/**` の変更
- `docs/**` の変更
- schema breaking change
- `element` key から `attribute` key への変更
- unknown growth key / unknown skill ability fields の strictness 強化
- 2D / 3D asset contract
- package変更
- CI変更

## 残した未決事項
- unknown field strictness は別PBIで扱います。
- `element` key を将来 `attribute` key へ変更するかは未決です。
- 2D / 3D asset contract は別PBIで扱います。

## 確認結果
- `npm run passport:smoke`: 成功
- `npm run build`: 成功
- `npm run test:domain`: 成功
- 初回の sandbox 実行では esbuild 起動が `EPERM` になったため、build / test:domain は通常権限で再実行して成功しています。
- GitHub Actions の build / guard はPR上で確認してください。