### PR TITLE
docs: 五行タクティクス資料をworld presetとして隔離する

### DIFF
--- a/docs/tactics-five-phases-glossary.md
+++ b/docs/tactics-five-phases-glossary.md
@@ -1,19 +1,29 @@
 # 五行タクティクス用語辞書
 
-この資料は、Character Passport v1 と将来の五行ベースのタクティクス戦闘ゲームに向けて、用語の意味を固定するための辞書です。
+## 現在の位置づけ
+
+この資料は、現行の Character Passport core contract ではありません。
+ここにある五行と職種、ステータス、状態異常、バフ、デバフの対応は、legacy / historical concept を含む GodSandbox world preset です。
+
+Character Passport の安定JSONインターフェースでは、属性（`element`）と職種（`combatClass`）、基本ステータス、状態異常、バフ、デバフ、Skill、Ability は独立したパラメータとして扱います。
+後続ゲームはこの五行presetを採用してもよいですが、採用しなくても構いません。
+後続ゲームは、受け取った属性や職種の名前・意味を自分のゲーム内で自由に再解釈できます。
+
+この資料は、GodSandbox が過去に検討した五行ベースのタクティクス戦闘案を保存し、必要な場合に world preset として参照できるようにするための辞書です。
 
 これは設計辞書であり、実装ではありません。実行時挙動、戦闘式、API、永続化ルールはここでは定義しません。
 
 ## この資料の目的
 
-- 五行タクティクス用語の解釈を開発者間で揃える。
-- 戦闘コードが存在する前に、Character Passport v1 の各項目を読める状態にする。
-- 用語の決定と、将来の実装詳細を分離する。
+- GodSandbox world preset としての五行タクティクス用語の解釈を保存する。
+- 旧設計が現行 Passport core contract と誤読されないように境界を明示する。
+- 用語の保存と、現行 Character Passport 安定JSONインターフェースを分離する。
 
 ## 五行と職種
 
-この資料では、木（wood）、火（fire）、土（earth）、金（metal）、水（water）を五行（element）として扱います。
-MVP では、職種（combatClass）と五行は 1:1 で対応します。
+この GodSandbox world preset では、木（wood）、火（fire）、土（earth）、金（metal）、水（water）を五行（element）として扱います。
+この preset 内では、職種（combatClass）と五行を 1:1 で対応させます。
+ただし、この対応は Character Passport 全体の契約ではありません。
 
 ```text
 wood  = ranger
@@ -23,11 +33,11 @@ metal = knight
 water = healer
 ```
 
-MVP でのルール:
+legacy / world preset 内でのルール:
 
 ```text
-MVPでは element と combatClass は 1:1 固定。
-将来は分離可能だが、v1では分離しない。
+この GodSandbox world preset では element と combatClass を 1:1 対応として扱う。
+現行 Character Passport core では element と combatClass は独立した値として扱う。
 ```
 
 ## 五行の代表機能
@@ -70,6 +80,9 @@ Healer:
 
 ## 基本ステータス
 
+以下は GodSandbox world preset 内での五行イメージです。
+Character Passport core では、属性が基本ステータスを支配する仕様ではありません。
+
 ```text
 Vision:
 木。視野、索敵、罠発見、反応範囲。
@@ -110,6 +123,9 @@ Entangled:
 
 ## 状態異常
 
+以下は GodSandbox world preset 内の対応です。
+Character Passport core では、属性が状態異常を支配する仕様ではありません。
+
 ```text
 wood  = Rooted
 fire  = Burning
@@ -123,6 +139,9 @@ water = Chilled
 
 ## バフ
 
+以下は GodSandbox world preset 内の対応です。
+Character Passport core では、属性がバフを支配する仕様ではありません。
+
 ```text
 wood  = Growth
 fire  = Ignite
@@ -132,6 +151,9 @@ water = Flowing
 ```
 
 ## デバフ
+
+以下は GodSandbox world preset 内の対応です。
+Character Passport core では、属性がデバフを支配する仕様ではありません。
 
 ```text
 wood  = Entangled
@@ -222,7 +244,8 @@ chaosExposure:
 ## 相生 / 相剋
 
 数値倍率はまだ決めません。
-MVP では効果カテゴリだけを定義します。
+この GodSandbox world preset では効果カテゴリだけを定義します。
+後続ゲームはこの相生 / 相剋を採用してもよいですが、採用しなくても構いません。
 
 相生:
 
@@ -274,6 +297,9 @@ Knight が Ranger の拘束・罠・蔦を切断する
 
 五行ごとの範囲傾向:
 
+以下は GodSandbox world preset の攻撃範囲傾向です。
+Character Passport core の必須仕様ではありません。
+
 ```text
 wood:
 枝分かれ、斜め、罠、視野範囲
@@ -292,6 +318,9 @@ water:
 ```
 
 ## canonical key 一覧
+
+以下の canonical key は、この legacy / GodSandbox world preset を読むためのキー一覧です。
+現行 Character Passport core contract における属性独立方針を上書きするものではありません。
 
 ```text
 elements:

--- a/docs/tactics-growth-and-abilities-glossary.md
+++ b/docs/tactics-growth-and-abilities-glossary.md
@@ -1,14 +1,22 @@
 # 成長と特殊能力の用語辞書
 
-この資料は、Character Passport v1 が現在の最小スキーマから拡張される前に、加護（Blessing）、試練（Trial）、カオス（Chaos）、成長（growth）、特殊能力（abilities）の意味を固定するための用語辞書です。
+## 現在の位置づけ
+
+この資料は、加護（Blessing）、試練（Trial）、カオス（Chaos）、成長（growth）、特殊能力（abilities）を整理した旧設計を含む用語辞書です。
+五行別の `growth` 構造や、能力の `element` を前提にした例は、legacy / historical concept を含む GodSandbox world preset として扱います。
+
+現行の Character Passport core contract では、属性（`element`）は有限パラメータの1つであり、Skill、Ability、成長、職種を支配しません。
+後続ゲームは、この資料の五行presetを採用してもよいですが、採用しなくても構いません。
+後続ゲームは、受け取った属性や職種、Skill、Ability の意味を自分のゲーム内で自由に再解釈できます。
 
 これは設計辞書であり、実装ではありません。数式、実行時挙動、REST API、フロントエンド UI は定義しません。
 
 ## この資料の目的
 
 - 加護 / 試練 / カオスを、信仰度（Faith）だけでなく、成長・耐性・特殊能力の源泉として扱う。
-- Character Passport v1 の実装が拡張される前に、`growth` と `abilities` の意味を固定する。
-- 将来のタクティクスゲーム開発者が、キャラクター export データを同じ意味で読めるようにする。
+- legacy / GodSandbox world preset における `growth` と `abilities` の意味を保存する。
+- 旧設計が現行 Passport core contract と誤読されないように境界を明示する。
+- 将来のタクティクスゲーム開発者が、必要な部分だけを読み、不要な部分をスキップできるようにする。
 
 ## 加護 / 試練 / カオス
 
@@ -34,6 +42,9 @@ Chaos:
 ```
 
 ## 成長（growth）構造案
+
+以下は legacy / GodSandbox world preset の構造案です。
+現行 Character Passport core contract で、成長が必ず五行別ベクトルであることを要求するものではありません。
 
 ```json
 {
@@ -64,6 +75,9 @@ Chaos:
 ```
 
 ## 成長要素の影響先
+
+以下は GodSandbox world preset 内での成長解釈です。
+現行 Character Passport core contract では、属性や成長カテゴリが他パラメータを支配する仕様ではありません。
 
 ```text
 Blessing:
@@ -136,6 +150,9 @@ Character Passport v1 では、能動行動は `skills` に保存する。
 
 ## ability schema 案
 
+以下は GodSandbox world preset で能力を表現する場合の案です。
+`element` は能力を分類するための任意の属性値であり、Character Passport core contract 全体で能力の効果や職種を支配するものではありません。
+
 ```json
 {
   "id": "iron-vow",
@@ -188,6 +205,9 @@ Character Passport v1 は次の保存先を維持する:
 - skills: 能動行動
 - abilities: passive / reaction / aura 効果
 ```
+
+この分離は stable interface として維持します。
+ただし、この資料内の五行別成長や element 付き能力例は GodSandbox world preset の旧設計であり、すべての後続ゲームに採用を要求するものではありません。
 
 ## 今回まだ決めないもの
 


### PR DESCRIPTION
## 対象PBI
PBI-TACTICS-FIVE-PHASES-LEGACY-PRESET-001

## 対応Issue
Closes #77

## branch
`docs/pbi-tactics-five-phases-legacy-preset-001`

## 変更ファイル
- `docs/tactics-five-phases-glossary.md`
- `docs/tactics-growth-and-abilities-glossary.md`

## 今回やったこと
- 五行タクティクス資料を、現行の Character Passport core contract ではなく legacy / GodSandbox world preset として位置づけ直しました。
- `wood = ranger` などの固定対応は、この world preset 内の説明であり、Character Passport 全体の契約ではないと明記しました。
- 五行が基本ステータス、状態異常、バフ、デバフ、Skill、Ability を支配する記述は、Passport core contract ではなく world preset 内の旧設計であると明記しました。
- 後続ゲームはこの五行presetを採用してもよいが、採用しなくてもよいと明記しました。
- 後続ゲームは属性や職種の意味を自由に再解釈できると明記しました。

## 今回やらないこと
- Domain model 修正
- server export 修正
- smoke修正
- sample JSON修正
- Character Passport stable interface の書き換え
- 2D / 3D asset contract の確定
- 汎用パラメータ種類と数の確定
- package変更
- CI変更

## scope外変更
- `server/**`: 変更なし
- `src/**`: 変更なし
- `samples/**`: 変更なし
- `package.json` / `package-lock.json`: 変更なし
- `.github/**`: 変更なし

## レーンAと競合しない理由
- 本PRは docs-only で、変更対象は tactics 関連docs 2ファイルのみです。
- レーンAが担当する `server/**` には触れていません。
- `src/**`、`samples/**`、package、CI workflow にも触れていません。

## build / guard 結果
- ローカル `npm run build`: 成功
- smoke結果: 対象外（docs-onlyで server export / smoke は変更していないため）
- GitHub Actions の build / guard はPR上で確認してください。

## 後続判断が必要な点
- tactics系資料を将来どの程度 GodSandbox world preset として残すか
- 汎用パラメータ種類と数の確定
- 2D / 3D asset contract の整理