### PR TITLE
server: Character Passport export strictnessを強化する

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -249,6 +249,19 @@ v1 では次の 5 種のみ許可します。
 `characterId` は export ファイル名に使われます。
 安全のため、空文字、`/`、`\`、`..` を含む値は拒否します。
 
+## export strictness
+
+server export は、育成ゲームが公開する正規の Character Passport を作る側です。
+そのため、安定JSONインターフェースで許可していない unknown field は reject します。
+
+MVPでは strip ではなく reject を優先します。
+unknown field を黙って削ると、入力側の設計ミスや未定義拡張に気づきにくいためです。
+
+特に `growth` の unknown key、`skills` の unknown field、`abilities` の unknown field は `npm run passport:smoke` で拒否を確認します。
+
+これは後続ゲーム側が不要な既知パラメータをスキップできる方針とは矛盾しません。
+server export は正規Passportを作る側であり、後続ゲームはPassportを読む側です。
+
 ## 出力先
 
 ```text
@@ -274,6 +287,7 @@ npm run passport:smoke
 4. `element` と `combatClass` が独立した値として保存される
 5. `characterId` の path traversal / slash を拒否できる
 6. Domain canonical 定義と server export contract が drift していない
+7. `growth` / `skills` / `abilities` の unknown field を拒否できる
 
 ## 今回まだ含まないもの
 

--- a/server/character-passport.mjs
+++ b/server/character-passport.mjs
@@ -24,6 +24,48 @@ const VALID_OBEDIENCE_BIASES = new Set(PASSPORT_EXPORT_CONTRACT.faithObedienceBi
 const VALID_COMMAND_INTERPRETATIONS = new Set(PASSPORT_EXPORT_CONTRACT.faithCommandInterpretations);
 const VALID_HAZARD_RESPONSES = new Set(PASSPORT_EXPORT_CONTRACT.faithHazardResponses);
 const VALID_AUTONOMY_ALIGNMENTS = new Set(PASSPORT_EXPORT_CONTRACT.faithAutonomyAlignments);
+const ALLOWED_SKILL_FIELDS = Object.freeze([
+  'kind',
+  'id',
+  'name',
+  'element',
+  'skillType',
+  'description',
+  'targetPattern',
+  'range',
+  'powerPerTile',
+  'secondaryEffect',
+]);
+const ALLOWED_ABILITY_FIELDS = Object.freeze([
+  'kind',
+  'id',
+  'name',
+  'source',
+  'element',
+  'abilityType',
+  'description',
+  'trigger',
+  'effects',
+]);
+const ALLOWED_TRIGGER_FIELDS_BY_TYPE = Object.freeze({
+  onTurnStart: ['type'],
+  onTurnEnd: ['type'],
+  onStatusReceived: ['type', 'status'],
+  onAllyDamaged: ['type'],
+  onFaithCommand: ['type', 'commandTag'],
+  manual: ['type'],
+});
+const ALLOWED_EFFECT_FIELDS_BY_TYPE = Object.freeze({
+  buff: ['type', 'key', 'value', 'duration', 'target'],
+  debuff: ['type', 'key', 'value', 'duration', 'target'],
+  statusCondition: ['type', 'key', 'duration', 'target'],
+  heal: ['type', 'value', 'target'],
+  damage: ['type', 'value', 'target'],
+  move: ['type', 'value', 'target'],
+  cleanse: ['type', 'target', 'key'],
+  summon: ['type', 'value', 'target'],
+  modifyFaith: ['type', 'value', 'target'],
+});
 
 function assertSafeName(name, label) {
   if (!name || typeof name !== 'string') {
@@ -64,6 +106,16 @@ function assertEnum(value, set, label) {
   }
 }
 
+function assertAllowedKeys(record, allowedKeys, label) {
+  const allowedSet = new Set(allowedKeys);
+
+  for (const key of Object.keys(record)) {
+    if (!allowedSet.has(key)) {
+      throw new Error(`Unexpected ${label}.${key} field. Allowed fields: ${allowedKeys.join(', ')}.`);
+    }
+  }
+}
+
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -94,6 +146,7 @@ function getFaithTrustBand(value) {
 
 function assertFivePhaseValueMap(record, label) {
   assertPlainObject(record, label);
+  assertAllowedKeys(record, PASSPORT_EXPORT_CONTRACT.fivePhaseElements, label);
 
   for (const key of PASSPORT_EXPORT_CONTRACT.fivePhaseElements) {
     assertFiniteNumber(record[key], `${label}.${key}`);
@@ -147,6 +200,7 @@ function normalizeFaith(faith) {
 
 function normalizeGrowth(growth) {
   assertPlainObject(growth, 'growth');
+  assertAllowedKeys(growth, PASSPORT_EXPORT_CONTRACT.growthCategories, 'growth');
   assertFivePhaseValueMap(growth.blessings, 'growth.blessings');
   assertFivePhaseValueMap(growth.trials, 'growth.trials');
   assertFivePhaseValueMap(growth.chaosExposure, 'growth.chaosExposure');
@@ -158,15 +212,39 @@ function normalizeGrowth(growth) {
   };
 }
 
+function assertTypedAllowedKeys(record, allowedFieldsByType, label) {
+  assertPlainObject(record, label);
+  assertNonEmptyString(record.type, `${label}.type`);
+
+  const allowedKeys = allowedFieldsByType[record.type];
+  if (!allowedKeys) {
+    throw new Error(`Invalid ${label}.type "${record.type}". Expected one of: ${Object.keys(allowedFieldsByType).join(', ')}`);
+  }
+
+  assertAllowedKeys(record, allowedKeys, label);
+}
+
+function assertTacticsEffect(effect, label) {
+  assertTypedAllowedKeys(effect, ALLOWED_EFFECT_FIELDS_BY_TYPE, label);
+}
+
+function assertAbilityTrigger(trigger, label) {
+  assertTypedAllowedKeys(trigger, ALLOWED_TRIGGER_FIELDS_BY_TYPE, label);
+}
+
 function normalizeSkills(skills) {
   assertArray(skills, 'skills');
 
   return skills.map((skill, index) => {
     assertPlainObject(skill, `skills[${index}]`);
+    assertAllowedKeys(skill, ALLOWED_SKILL_FIELDS, `skills[${index}]`);
     assertNonEmptyString(skill.id, `skills[${index}].id`);
     assertNonEmptyString(skill.name, `skills[${index}].name`);
     assertEnum(skill.kind, new Set(['skill']), `skills[${index}].kind`);
     assertEnum(skill.element, VALID_ELEMENTS, `skills[${index}].element`);
+    if (skill.secondaryEffect !== undefined) {
+      assertTacticsEffect(skill.secondaryEffect, `skills[${index}].secondaryEffect`);
+    }
 
     return cloneJson(skill);
   });
@@ -177,10 +255,16 @@ function normalizeAbilities(abilities) {
 
   return abilities.map((ability, index) => {
     assertPlainObject(ability, `abilities[${index}]`);
+    assertAllowedKeys(ability, ALLOWED_ABILITY_FIELDS, `abilities[${index}]`);
     assertNonEmptyString(ability.id, `abilities[${index}].id`);
     assertNonEmptyString(ability.name, `abilities[${index}].name`);
     assertEnum(ability.kind, new Set(['ability']), `abilities[${index}].kind`);
     assertEnum(ability.element, VALID_ELEMENTS, `abilities[${index}].element`);
+    assertAbilityTrigger(ability.trigger, `abilities[${index}].trigger`);
+    assertArray(ability.effects, `abilities[${index}].effects`);
+    ability.effects.forEach((effect, effectIndex) => {
+      assertTacticsEffect(effect, `abilities[${index}].effects[${effectIndex}]`);
+    });
 
     return cloneJson(ability);
   });
@@ -367,6 +451,20 @@ function assertExportJsonMatchesContract(saved) {
   }
 }
 
+function assertRejects(fn, expectedMessage, label) {
+  try {
+    fn();
+    console.error(`FAIL: should have rejected ${label}`);
+    process.exit(1);
+  } catch (err) {
+    if (!err.message.includes(expectedMessage)) {
+      console.error(`FAIL: unexpected ${label} error:`, err.message);
+      process.exit(1);
+    }
+    console.log(`${label} rejected:`, err.message);
+  }
+}
+
 if (process.argv[2] === 'smoke') {
   console.log('passport:smoke start');
 
@@ -399,6 +497,49 @@ if (process.argv[2] === 'smoke') {
   console.log('passport schema ok:', saved.schemaVersion);
   console.log('passport adapter ok:', `${saved.element}/${saved.combatClass}`);
   console.log('element/combatClass independence preserved:', `${saved.element}/${saved.combatClass}`);
+
+  assertRejects(
+    () =>
+      adaptCharacterPassportSourceToExport({
+        ...sampleRenPassportSource(),
+        growth: {
+          ...sampleRenPassportSource().growth,
+          customGrowth: emptyFivePhaseValues(),
+        },
+      }),
+    'growth.customGrowth',
+    'unknown growth key',
+  );
+
+  assertRejects(
+    () =>
+      adaptCharacterPassportSourceToExport({
+        ...sampleRenPassportSource(),
+        skills: [
+          {
+            ...sampleRenPassportSource().skills[0],
+            customSkillField: true,
+          },
+        ],
+      }),
+    'skills[0].customSkillField',
+    'unknown skill field',
+  );
+
+  assertRejects(
+    () =>
+      adaptCharacterPassportSourceToExport({
+        ...sampleRenPassportSource(),
+        abilities: [
+          {
+            ...sampleRenPassportSource().abilities[0],
+            customAbilityField: true,
+          },
+        ],
+      }),
+    'abilities[0].customAbilityField',
+    'unknown ability field',
+  );
 
   try {
     await writeCharacterPassportFile({ ...passport, characterId: '../outside' });


### PR DESCRIPTION

Closes #76

## 対象PBI

PBI-PASSPORT-EXPORT-STRICTNESS-001

## 対応Issue

- #76

## branch

- server/pbi-passport-export-strictness-001

## 概要

Character Passport export は正規のPassportを作る側なので、安定JSONインターフェース外の unknown field を reject するように runtime validation を強化します。

後続ゲーム側が不要な既知パラメータをスキップできる方針とは別に、server export では未定義拡張を通さないことで、有限パラメータ方針を守ります。

## 変更ファイル

- server/character-passport.mjs
- server/README.md

## 追加内容

- `growth` / `growth.<category>` の unknown key を reject
- `skills[]` の unknown field を reject
- `abilities[]` の unknown field を reject
- `skills[].secondaryEffect`、`abilities[].trigger`、`abilities[].effects[]` の許可fieldを type ごとに確認
- reject時に `growth.customGrowth` や `skills[0].customSkillField` のように問題fieldが分かるエラーメッセージを出す
- `npm run passport:smoke` に unknown growth / skill / ability の拒否確認を追加
- README に export strictness 方針を追記

## strictness方針

MVPでは strip ではなく reject を優先します。
unknown field を黙って削ると、入力側の設計ミスや未定義拡張に気づきにくいためです。

## 今回やらないこと

- Domain model 修正
- 属性と combatClass の独立方針の再設計
- element key から attribute key への変更
- 2D / 3D asset contract
- Skill / Ability の最終語彙確定
- Character Passport schema の大幅変更
- REST API 拡張
- frontend UI
- docs/** の修正
- package変更
- CI workflow変更

## scope外変更がないこと

- src/** は変更していません
- docs/** は変更していません
- samples/** は変更していません
- public/** は変更していません
- package.json / package-lock.json は変更していません
- .github/** は変更していません

## レーンBとの分離

本PRは server/** のみを変更します。
レーンBは docs/** の指定ファイルのみ担当のため、変更ファイルが分かれており競合しません。

## build / guard / smoke 結果

- main追従: `git fetch origin` 後、`git merge origin/main` は `Already up to date`
- build: `npm run build` OK
- Domain tests: `npm run test:domain` OK
- smoke: `npm run passport:smoke` OK
- guard: PR作成後のGitHub Actionsで確認

## 後続判断が必要な点

- Skill / Ability の最終語彙確定は別PBI
- element key から attribute key へ変更するかは未決
- 2D / 3D asset contract は未決

## 監査観点

- unknown growth key / skill field / ability field が reject されること
- reject時に問題fieldが分かること
- READMEで server export の reject 方針と後続ゲームの skip 方針が分かれていること
- server/** 以外に変更が混ざっていないこと
