### PR TITLE
ops: Ryo画像参照を artPaths に揃える

### DIFF
--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -43,10 +43,10 @@ function getPanelPortraitSrc(paused: boolean, latestJudgement: JudgementResult |
 
 function getPortraitGuide(name?: string) {
   return {
-    subjectLabel: "アート基準キャラ: Ryo（後続PBIで正式追加）",
+    subjectLabel: "アート基準キャラ: Ryo（portrait 接続済み）",
     toneLabel: name ? `現在の表示対象: ${name}` : "現在の表示対象: なし",
     expressionLine: "推奨差分: 平静 / 気づき / 緊張 / 覚悟",
-    note: "この枠は、Ryo の表情差分を後続PBIで差し替え運用できる generic な portrait 受け皿です。",
+    note: "この枠は、artPaths.ts の Ryo 表情差分を参照する generic な portrait 受け皿です。",
   };
 }
 


### PR DESCRIPTION
対象PBI: PBI-OPS-ART-002
対応Issue: #82
Closes #82
branch: ops/pbi-ops-art-002-artpaths-import

## 変更ファイル
- src/features/apostle/ApostlePanel.tsx

## 今回やったこと
- EventModal / ApostlePanel / presentation 層の Ryo 画像パス直書きを確認し、直書きが src/assets/artPaths.ts のみに閉じていることを確認しました。
- ApostlePanel の Ryo portrait 表示文言を、実画像が接続済みである状態と artPaths.ts 参照に合わせました。
- placeholder fallback と表示構造は変更していません。

## 今回やらないこと
- Character Passport 関連docsの変更
- export / import 実装
- domain model 変更
- 画像生成
- 新規画像ファイル追加
- UIデザインの大幅変更
- CSSの大幅変更
- 画像表示比率の本格調整
- package変更
- CI変更

## scope外変更がないこと
- Passport 関連ファイルは変更していません。
- server / docs / samples / package / CI workflow は変更していません。
- 変更ファイルは ApostlePanel.tsx のみです。

## 他PBIと競合しない理由
- 本PRは presentation 層の Ryo portrait 表示文言のみを扱います。
- Character Passport / 外部ゲームIF仕様監査、export/import仕様、domain model には触れていないため独立しています。

## build / guard / smoke 結果
- npm run typecheck: 成功
- npm run build: 成功（Vite の chunk size warning のみ）
- guard: package.json に guard script がないため対象外
- smoke: server / Passport export 対象ではないため対象外

## main追従
- git fetch origin 実行済み
- git merge origin/main: Already up to date

## 後続判断が必要な点
- なし