### PR TITLE
sample: 育てたキャラを別ゲームで読み込む最小サンプル

### DIFF
--- a/samples/passport-consumer/README.md
+++ b/samples/passport-consumer/README.md
@@ -1,0 +1,95 @@
+# Character Passport consumer sample
+
+このサンプルは、GodSandbox で育てたキャラクター情報を、別のゲーム側で読む一番小さい例です。
+
+ここでは、外部ゲームや自作ツールのことを **Passport consumer** と呼びます。むずかしく言うと「Character Passport を読む側」ですが、まずは「別ゲーム側」と考えてください。
+
+## このサンプルで分かること
+
+- Character Passport は、外へ渡すキャラクター紹介カードのようなJSONです。
+- 別ゲーム側は、必要な項目だけ読めばよいです。
+- 使わない項目は無視してよいです。
+- 別ゲーム側では、仲間、敵、NPC、カード、村人などに自由に使い直してよいです。
+- GodSandbox の内部状態や domain model をそのまま再現する必要はありません。
+
+## ファイル
+
+- `sample-passport.json`: 別ゲーム側が読むサンプルの Character Passport JSON
+- `index.html`: ブラウザで見るための小さな画面
+- `main.js`: JSONを読んで、画面に表示する処理
+
+## 動かし方
+
+まずは `index.html` をブラウザで開いてください。
+
+ブラウザの制限で `sample-passport.json` を直接読めない場合があります。その場合でも、画面には同じ内容の予備データが表示されます。
+
+実際にJSON読み込みを確認したい場合は、このディレクトリで簡単なローカルサーバーを起動してください。
+
+```bash
+python -m http.server 8080
+```
+
+その後、ブラウザで次を開きます。
+
+```text
+http://localhost:8080/
+```
+
+## どの値を変えると表示が変わるか
+
+`sample-passport.json` の次の値を変えると、画面の表示が変わります。
+
+- `name`: キャラクター名
+- `characterId`: 画像や外部ゲーム側の扱いを選ぶためのID
+- `element`: 属性。別ゲーム側では自由に意味を変えてよいです。
+- `combatClass`: 職種。属性から自動で決まるものではありません。
+- `faith.trustBand`: 神への信頼の強さを、別ゲーム側の説明に使えます。
+
+## このサンプルが読んでいる項目
+
+このconsumerは、Character Passport の全項目を読みません。
+
+画面表示に使うのは、主に次だけです。
+
+- `characterId`
+- `name`
+- `element`
+- `combatClass`
+- `faith.trustBand`
+
+`baseAttributes`、`growth`、`skills`、`abilities` は、今回は表示の補助として少しだけ使います。別ゲーム側で不要なら無視してかまいません。
+
+## 外部ゲーム側での使い方例
+
+このサンプルでは、Ryo を次のように読み替えています。
+
+- 村人NPC
+- 仲間候補
+- カードゲームのユニット
+- チュートリアル用キャラクター
+
+このように、Character Passport の値は、後続ゲーム側で自由に再解釈できます。
+
+## 今回やっていないこと
+
+- 本格的な外部ゲーム制作
+- SDK作成
+- npm package作成
+- REST API
+- ログイン
+- 認証
+- オンライン連携
+- export画面の本実装
+- import画面の本実装
+- LLM連携
+- secret handling
+- GodSandbox内部domain modelの変更
+
+## 大事な境界
+
+Character Passport は外へ渡すJSONです。
+
+発話生成のための live context や、神との会話履歴ではありません。
+
+別ゲーム側は、このJSONを読んで、自分のゲームに必要な形へ取り込めば十分です。

--- a/samples/passport-consumer/README.md
+++ b/samples/passport-consumer/README.md
@@ -24,7 +24,7 @@
 
 ブラウザの制限で `sample-passport.json` を直接読めない場合があります。その場合でも、画面には同じ内容の予備データが表示されます。
 
-実際にJSON読み込みを確認したい場合は、このディレクトリで簡単なローカルサーバーを起動してください。
+実際にJSON読み込みと顔画像の表示を確認したい場合は、repo root で簡単なローカルサーバーを起動してください。
 
 ```bash
 python -m http.server 8080
@@ -33,8 +33,10 @@ python -m http.server 8080
 その後、ブラウザで次を開きます。
 
 ```text
-http://localhost:8080/
+http://localhost:8080/samples/passport-consumer/
 ```
+
+この手順なら、`sample-passport.json` と `public/art/...` のRyo portrait画像を同じローカルサーバーから読めます。
 
 ## どの値を変えると表示が変わるか
 

--- a/samples/passport-consumer/index.html
+++ b/samples/passport-consumer/index.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Character Passport consumer sample</title>
+    <style>
+      :root {
+        color: #1f251f;
+        background: #f5efe3;
+        font-family: "Yu Gothic", "Hiragino Sans", Meiryo, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background:
+          radial-gradient(circle at 20% 10%, rgba(141, 188, 129, 0.32), transparent 26rem),
+          linear-gradient(135deg, #fbf4e6, #e5ead9 58%, #d5e0cf);
+      }
+
+      main {
+        box-sizing: border-box;
+        width: min(960px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 40px 0;
+      }
+
+      .hero {
+        margin-bottom: 24px;
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        color: #66735d;
+        font-size: 0.85rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 7vw, 4.5rem);
+        line-height: 0.95;
+      }
+
+      .consumer-card {
+        display: grid;
+        grid-template-columns: minmax(180px, 280px) 1fr;
+        gap: 24px;
+        padding: 24px;
+        border: 1px solid rgba(45, 61, 42, 0.2);
+        border-radius: 28px;
+        background: rgba(255, 252, 244, 0.82);
+        box-shadow: 0 24px 80px rgba(39, 53, 33, 0.16);
+      }
+
+      .portrait {
+        position: relative;
+        overflow: hidden;
+        min-height: 320px;
+        border-radius: 22px;
+        background: #d9dfd0;
+      }
+
+      .portrait img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        min-height: 320px;
+        object-fit: cover;
+      }
+
+      .portrait-fallback {
+        display: grid;
+        min-height: 320px;
+        place-items: center;
+        color: #66735d;
+        font-size: 3rem;
+        font-weight: 800;
+      }
+
+      .content {
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      .summary {
+        margin: 0;
+        color: #3d4739;
+        font-size: 1.08rem;
+        line-height: 1.8;
+      }
+
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .tag {
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: #e7eddc;
+        color: #3c5738;
+        font-size: 0.9rem;
+        font-weight: 700;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .note {
+        padding: 14px;
+        border-radius: 16px;
+        background: rgba(241, 233, 214, 0.75);
+      }
+
+      .note strong {
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      .note p {
+        margin: 0;
+        color: #586150;
+        line-height: 1.6;
+      }
+
+      .status {
+        margin-top: 16px;
+        color: #66735d;
+        font-size: 0.92rem;
+      }
+
+      .status--warn {
+        color: #8b5a28;
+      }
+
+      @media (max-width: 720px) {
+        main {
+          width: min(100% - 20px, 960px);
+          padding: 24px 0;
+        }
+
+        .consumer-card {
+          grid-template-columns: 1fr;
+          padding: 16px;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <p class="eyebrow">Passport consumer sample</p>
+        <h1>育てたキャラを、別ゲームで読む</h1>
+      </section>
+
+      <section id="app" class="consumer-card" aria-live="polite">
+        <div class="portrait">
+          <div class="portrait-fallback">?</div>
+        </div>
+        <div class="content">
+          <p class="summary">Character Passport を読み込み中です。</p>
+        </div>
+      </section>
+
+      <p id="status" class="status">sample-passport.json を読み込んでいます。</p>
+    </main>
+
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/samples/passport-consumer/main.js
+++ b/samples/passport-consumer/main.js
@@ -1,0 +1,211 @@
+const fallbackPassport = {
+  schemaVersion: 'character-passport/v1',
+  characterId: 'ryo-sample-001',
+  name: 'Ryo',
+  originGame: 'god-sandbox-mvp',
+  element: 'wood',
+  combatClass: 'healer',
+  baseAttributes: {
+    vision: 4,
+    power: 2,
+    guard: 3,
+    discipline: 3,
+    flow: 5,
+  },
+  faith: {
+    value: 58,
+    obedienceBias: 'adaptive',
+    commandInterpretation: 'contextual',
+    hazardResponse: 'guarded',
+    autonomyAlignment: 'balanced',
+    trustBand: 'steady',
+    sources: {
+      blessings: 2,
+      trials: 1,
+      chaosExposure: 1,
+    },
+  },
+  growth: {
+    blessings: { wood: 1, fire: 0, earth: 0, metal: 0, water: 1 },
+    trials: { wood: 0, fire: 0, earth: 1, metal: 0, water: 0 },
+    chaosExposure: { wood: 1, fire: 0, earth: 0, metal: 0, water: 0 },
+  },
+  skills: [
+    {
+      kind: 'skill',
+      id: 'forest-first-aid',
+      name: 'Forest First Aid',
+      element: 'water',
+      skillType: 'heal',
+      description: '森で覚えた手当てで、近くの仲間を落ち着かせる。',
+      targetPattern: 'adjacent',
+      range: 1,
+      powerPerTile: 1,
+      secondaryEffect: {
+        type: 'buff',
+        key: 'flowing',
+        value: 1,
+        duration: 1,
+        target: 'ally',
+      },
+    },
+  ],
+  abilities: [
+    {
+      kind: 'ability',
+      id: 'listens-before-acting',
+      name: 'Listens Before Acting',
+      source: 'blessing',
+      element: 'wood',
+      abilityType: 'passive',
+      description: '急いで決めず、周囲の様子を見てから動く。',
+      trigger: {
+        type: 'onTurnStart',
+      },
+      effects: [
+        {
+          type: 'buff',
+          key: 'growth',
+          value: 1,
+          duration: 1,
+          target: 'self',
+        },
+      ],
+    },
+  ],
+};
+
+const elementLabels = {
+  wood: '森の気配',
+  fire: '熱い意志',
+  earth: '落ち着き',
+  metal: '規律',
+  water: '流れ',
+};
+
+const classLabels = {
+  ranger: '案内役',
+  mage: '術を使う人',
+  guardian: '守る人',
+  knight: '境界を守る人',
+  healer: '手当てをする人',
+};
+
+const trustLabels = {
+  dismissive: '神の声をほとんど信じていない',
+  wary: '少し疑いながら聞いている',
+  steady: '落ち着いて受け取っている',
+  trusting: 'かなり信頼している',
+  devoted: '強く信じている',
+};
+
+const portraitByCharacterId = {
+  'ryo-sample-001': '../../public/art/portraits/ryo/ryo_normal.jpeg',
+};
+
+const app = document.querySelector('#app');
+const status = document.querySelector('#status');
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+async function loadPassport() {
+  try {
+    const response = await fetch('./sample-passport.json', { cache: 'no-store' });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    status.textContent = 'sample-passport.json を読み込みました。';
+    return response.json();
+  } catch (error) {
+    status.textContent =
+      'ブラウザの制限でJSONを直接読めなかったため、同じ内容の予備データを表示しています。実際のJSON読み込みは README のローカルサーバー手順で確認できます。';
+    status.classList.add('status--warn');
+    return fallbackPassport;
+  }
+}
+
+function makeSummary(passport) {
+  const name = passport.name ?? 'Unknown';
+  const element = elementLabels[passport.element] ?? passport.element ?? '未設定の属性';
+  const role = classLabels[passport.combatClass] ?? passport.combatClass ?? '役割未定';
+  const trust = trustLabels[passport.faith?.trustBand] ?? '神への向き合い方はまだ分からない';
+
+  return `${name} は ${element} を感じさせるキャラクターです。このサンプルでは、別ゲーム側で「${role}」として読み替えています。神の声は、${trust}状態です。`;
+}
+
+function makeTags(passport) {
+  const tags = [
+    passport.element ? `属性: ${elementLabels[passport.element] ?? passport.element}` : null,
+    passport.combatClass ? `使い方例: ${classLabels[passport.combatClass] ?? passport.combatClass}` : null,
+    passport.faith?.trustBand ? `信頼: ${trustLabels[passport.faith.trustBand] ?? passport.faith.trustBand}` : null,
+  ];
+
+  if (passport.growth?.chaosExposure) {
+    const chaosTotal = Object.values(passport.growth.chaosExposure).reduce((sum, value) => sum + Number(value ?? 0), 0);
+    tags.push(`カオス経験: ${chaosTotal}`);
+  }
+
+  return tags.filter(Boolean);
+}
+
+function renderPortrait(passport) {
+  const src = portraitByCharacterId[passport.characterId];
+
+  if (!src) {
+    return `<div class="portrait-fallback">${escapeHtml((passport.name ?? '?').slice(0, 1))}</div>`;
+  }
+
+  return `<img src="${escapeHtml(src)}" alt="${escapeHtml(passport.name ?? 'Character')} portrait" onerror="this.replaceWith(Object.assign(document.createElement('div'), { className: 'portrait-fallback', textContent: '${escapeHtml((passport.name ?? '?').slice(0, 1))}' }))" />`;
+}
+
+function render(passport) {
+  const skill = passport.skills?.[0];
+  const ability = passport.abilities?.[0];
+  const tags = makeTags(passport);
+
+  app.innerHTML = `
+    <div class="portrait">
+      ${renderPortrait(passport)}
+    </div>
+    <div class="content">
+      <div>
+        <p class="eyebrow">${escapeHtml(passport.schemaVersion ?? 'unknown schema')}</p>
+        <h1>${escapeHtml(passport.name ?? 'Unknown')}</h1>
+      </div>
+      <p class="summary">${escapeHtml(makeSummary(passport))}</p>
+      <div class="tags">
+        ${tags.map((tag) => `<span class="tag">${escapeHtml(tag)}</span>`).join('')}
+      </div>
+      <div class="grid">
+        <div class="note">
+          <strong>consumerが読んだ項目</strong>
+          <p>この画面は、主に name / characterId / element / combatClass / faith.trustBand だけを使っています。</p>
+        </div>
+        <div class="note">
+          <strong>使わなかった項目</strong>
+          <p>baseAttributes や growth の多くは無視しています。別ゲーム側は、不要な項目をスキップできます。</p>
+        </div>
+        <div class="note">
+          <strong>Skill の例</strong>
+          <p>${escapeHtml(skill ? `${skill.name}: ${skill.description}` : 'このconsumerではSkillを使っていません。')}</p>
+        </div>
+        <div class="note">
+          <strong>Ability の例</strong>
+          <p>${escapeHtml(ability ? `${ability.name}: ${ability.description}` : 'このconsumerではAbilityを使っていません。')}</p>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+const passport = await loadPassport();
+render(passport);

--- a/samples/passport-consumer/sample-passport.json
+++ b/samples/passport-consumer/sample-passport.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": "character-passport/v1",
+  "characterId": "ryo-sample-001",
+  "name": "Ryo",
+  "originGame": "god-sandbox-mvp",
+  "element": "wood",
+  "combatClass": "healer",
+  "baseAttributes": {
+    "vision": 4,
+    "power": 2,
+    "guard": 3,
+    "discipline": 3,
+    "flow": 5
+  },
+  "faith": {
+    "value": 58,
+    "obedienceBias": "adaptive",
+    "commandInterpretation": "contextual",
+    "hazardResponse": "guarded",
+    "autonomyAlignment": "balanced",
+    "trustBand": "steady",
+    "sources": {
+      "blessings": 2,
+      "trials": 1,
+      "chaosExposure": 1
+    }
+  },
+  "growth": {
+    "blessings": {
+      "wood": 1,
+      "fire": 0,
+      "earth": 0,
+      "metal": 0,
+      "water": 1
+    },
+    "trials": {
+      "wood": 0,
+      "fire": 0,
+      "earth": 1,
+      "metal": 0,
+      "water": 0
+    },
+    "chaosExposure": {
+      "wood": 1,
+      "fire": 0,
+      "earth": 0,
+      "metal": 0,
+      "water": 0
+    }
+  },
+  "skills": [
+    {
+      "kind": "skill",
+      "id": "forest-first-aid",
+      "name": "Forest First Aid",
+      "element": "water",
+      "skillType": "heal",
+      "description": "森で覚えた手当てで、近くの仲間を落ち着かせる。",
+      "targetPattern": "adjacent",
+      "range": 1,
+      "powerPerTile": 1,
+      "secondaryEffect": {
+        "type": "buff",
+        "key": "flowing",
+        "value": 1,
+        "duration": 1,
+        "target": "ally"
+      }
+    }
+  ],
+  "abilities": [
+    {
+      "kind": "ability",
+      "id": "listens-before-acting",
+      "name": "Listens Before Acting",
+      "source": "blessing",
+      "element": "wood",
+      "abilityType": "passive",
+      "description": "急いで決めず、周囲の様子を見てから動く。",
+      "trigger": {
+        "type": "onTurnStart"
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "key": "growth",
+          "value": 1,
+          "duration": 1,
+          "target": "self"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 対象PBI

PBI-PASSPORT-CONSUMER-SAMPLE-INTEGRATION-001

Closes #84

## branch

`sample/pbi-passport-consumer-sample-integration-001`

## 変更ファイル

- `samples/passport-consumer/README.md`
- `samples/passport-consumer/sample-passport.json`
- `samples/passport-consumer/index.html`
- `samples/passport-consumer/main.js`

## 追加内容

- 育てたキャラを別ゲーム側で読む、最小の Passport consumer sample を追加しました。
- `sample-passport.json` に、Ryo の Character Passport v1 形式のサンプルを追加しました。
- `index.html` と `main.js` で、サンプルJSONを読み、名前、顔画像、紹介文、タグ、使い方例を表示します。
- consumer側は必要な項目だけ読み、不要な項目をスキップできることをREADMEと画面内で示しました。
- `element` と `combatClass` は独立した値として扱い、別ゲーム側で自由に再解釈できることを説明しました。

## 今回やらないこと

- 本格的な外部ゲーム制作
- SDK作成
- npm package作成
- REST API
- ログイン / 認証 / オンライン連携
- export画面 / import画面の本実装
- LLM連携
- secret handling
- GodSandbox内部domain modelの変更
- package変更
- CI workflow変更

## scope外変更

- `src/**` は変更していません。
- `server/**` は変更していません。
- `docs/**` は変更していません。
- `package.json` / `package-lock.json` は変更していません。
- `.github/**` は変更していません。
- 未追跡のローカル補助ファイルは含めていません。

## 確認結果

- `node --check samples/passport-consumer/main.js`: 成功
- `sample-passport.json` の JSON parse: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
- `npm run test:domain`: 成功
- `npm run passport:smoke`: 成功
- GitHub `build` / `guard`: PR作成後に確認します

## 監査役に見てほしい点

- 初心者向けの説明として十分に読みやすいか
- Character Passport と live context を混ぜていないか
- consumer側が必要な項目だけ読む例になっているか
- 外部ゲーム側の自由な再解釈を壊していないか
- `element` / `combatClass` の独立方針に反していないか

## 後続判断

- このサンプルを起点に、次は `PBI-SAMPLE-CREATOR-WORKFLOW-001` で「作る -> 観察する -> exportする -> consumerで読む」流れをつなげるか判断してください。
