### PR TITLE
sample: Passport JSONを選んで対戦キャラに読み込む

### DIFF
--- a/sample-games/passport-paper-battle/README.md
+++ b/sample-games/passport-paper-battle/README.md
@@ -41,6 +41,35 @@ http://localhost:8080/sample-games/passport-paper-battle/
 4. 自キャラの行動後、敵が簡単な行動をする。
 5. 敵HPを0にすると勝利。自キャラHPが0になると敗北。
 
+## キャラ情報JSONを選ぶ
+
+画面左の「キャラ情報JSONを選ぶ」から、GodSandboxで保存したJSONファイルを選べます。
+
+読み込みに成功すると、次の表示が選んだキャラに変わります。
+
+- 名前
+- 画像
+- 紹介文
+- タグ
+
+JSONを選ばなくても、今まで通り固定サンプルのRyoで遊べます。
+
+このサンプルでは、Passportの全部の項目を使う必要はありません。
+まず使うのは、`displayName`、`portraitImage`、`summary`、`tags` だけです。
+
+JSONが読めない場合は、画面にやさしいエラー文が出ます。
+その場合でも画面は壊れず、今のキャラのまま遊べます。
+
+確認すること:
+
+- `.json` ファイルを選んでいるか
+- `displayName` が入っているか
+- `portraitImage` が画像の場所を指しているか
+- `tags` が文字の配列になっているか
+
+`portraitImage` が空の場合は、画像の代わりに名前の頭文字を表示します。
+古いサンプルのように `displayName` ではなく `name` だけが入っているJSONでも、名前として読める場合があります。
+
 ## Character Passport のうち使っているもの
 
 このサンプルの `sample-passport.json` は、次のような紹介カードです。

--- a/sample-games/passport-paper-battle/index.html
+++ b/sample-games/passport-paper-battle/index.html
@@ -27,6 +27,13 @@
           <h2 id="passportName">読み込み中</h2>
           <p id="passportSummary" class="summary">sample-passport.json を読み込んでいます。</p>
           <div id="passportTags" class="tags"></div>
+          <div class="file-load">
+            <label class="file-load__button" for="passportFile">キャラ情報JSONを選ぶ</label>
+            <input id="passportFile" type="file" accept="application/json,.json" />
+            <p id="fileStatus" class="file-load__status" aria-live="polite">
+              GodSandboxから保存したキャラ情報を選べます。選ばなくても、このサンプルのRyoで遊べます。
+            </p>
+          </div>
         </aside>
 
         <section class="battle-panel">

--- a/sample-games/passport-paper-battle/main.js
+++ b/sample-games/passport-paper-battle/main.js
@@ -16,6 +16,7 @@ const attackRange = 3;
 
 const state = {
   passport: fallbackPassport,
+  passportSource: "sample",
   selected: false,
   phase: "select",
   turn: 1,
@@ -41,6 +42,8 @@ const nodes = {
   battleLog: document.querySelector("#battleLog"),
   selectPlayer: document.querySelector("#selectPlayer"),
   reset: document.querySelector("#reset"),
+  passportFile: document.querySelector("#passportFile"),
+  fileStatus: document.querySelector("#fileStatus"),
 };
 
 function resolveSampleImagePath(src) {
@@ -63,6 +66,67 @@ async function loadPassport() {
   } catch (error) {
     addLog("JSONを直接読めなかったため、同じ内容の予備データで起動しました。");
     return fallbackPassport;
+  }
+}
+
+function normalizePassport(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("not-object");
+  }
+
+  const displayName =
+    typeof value.displayName === "string" && value.displayName.trim() !== ""
+      ? value.displayName.trim()
+      : typeof value.name === "string" && value.name.trim() !== ""
+        ? value.name.trim()
+        : "";
+
+  if (!displayName) {
+    throw new Error("missing-displayName");
+  }
+
+  return {
+    schemaVersion: typeof value.schemaVersion === "string" ? value.schemaVersion : "1.0",
+    characterId:
+      typeof value.characterId === "string" && value.characterId.trim() !== ""
+        ? value.characterId
+        : "loaded-passport-character",
+    displayName,
+    summary:
+      typeof value.summary === "string" && value.summary.trim() !== ""
+        ? value.summary.trim()
+        : "紹介文はまだありません。",
+    portraitImage:
+      typeof value.portraitImage === "string" && value.portraitImage.trim() !== ""
+        ? value.portraitImage.trim()
+        : undefined,
+    tags: Array.isArray(value.tags)
+      ? value.tags.filter((tag) => typeof tag === "string" && tag.trim() !== "").map((tag) => tag.trim())
+      : [],
+  };
+}
+
+async function loadPassportFromFile(file) {
+  if (!file) {
+    return;
+  }
+
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    state.passport = normalizePassport(parsed);
+    state.passportSource = "file";
+    state.fileStatusKind = "success";
+    state.fileStatus = `${state.passport.displayName}を読み込みました。`;
+    resetBattle();
+  } catch (error) {
+    state.fileStatusKind = "error";
+    state.fileStatus =
+      "このファイルは読み込めませんでした。GodSandboxから保存したキャラ情報JSONを選んでください。";
+    addLog("キャラ情報JSONを確認してください。今のキャラのまま遊べます。");
+    render();
+  } finally {
+    nodes.passportFile.value = "";
   }
 }
 
@@ -323,7 +387,19 @@ function renderPassport() {
       return element;
     }),
   );
+  renderFileStatus();
   renderPortrait();
+}
+
+function renderFileStatus() {
+  const defaultText =
+    state.passportSource === "file"
+      ? `${state.passport.displayName ?? "キャラ"}を読み込んでいます。別のJSONも選べます。`
+      : "GodSandboxから保存したキャラ情報を選べます。選ばなくても、このサンプルのRyoで遊べます。";
+
+  nodes.fileStatus.textContent = state.fileStatus ?? defaultText;
+  nodes.fileStatus.classList.toggle("file-load__status--error", state.fileStatusKind === "error");
+  nodes.fileStatus.classList.toggle("file-load__status--success", state.fileStatusKind === "success");
 }
 
 function renderPortrait() {
@@ -453,6 +529,13 @@ function render() {
 
 nodes.selectPlayer.addEventListener("click", selectPlayer);
 nodes.reset.addEventListener("click", resetBattle);
+nodes.passportFile.addEventListener("change", (event) => loadPassportFromFile(event.target.files?.[0]));
 
-state.passport = await loadPassport();
+try {
+  state.passport = normalizePassport(await loadPassport());
+} catch (error) {
+  state.passport = fallbackPassport;
+  state.fileStatusKind = "error";
+  state.fileStatus = "最初のサンプルJSONを読めなかったため、予備のRyoで起動しました。";
+}
 resetBattle();

--- a/sample-games/passport-paper-battle/style.css
+++ b/sample-games/passport-paper-battle/style.css
@@ -143,6 +143,54 @@ h1 {
   font-weight: 800;
 }
 
+.file-load {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.file-load input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.file-load__button {
+  display: inline-flex;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.72rem 1rem;
+  background: #2f5f43;
+  color: #fffaf0;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.file-load__button:hover {
+  transform: translateY(-1px);
+  background: #244d35;
+}
+
+.file-load__status {
+  margin: 0;
+  color: #5a664f;
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.file-load__status--error {
+  color: #8b3f2f;
+  font-weight: 700;
+}
+
+.file-load__status--success {
+  color: #2f5f43;
+  font-weight: 700;
+}
+
 .hud {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));


### PR DESCRIPTION
対象PBI: PBI-PASSPORT-SAMPLE-BATTLE-FILE-LOAD-001
対応Issue: #94
Closes #94
branch: sample/pbi-passport-sample-battle-file-load-001

## 変更ファイル
- sample-games/passport-paper-battle/index.html
- sample-games/passport-paper-battle/main.js
- sample-games/passport-paper-battle/style.css
- sample-games/passport-paper-battle/README.md

## 今回やったこと
- 1対1サンプル対戦ゲームに「キャラ情報JSONを選ぶ」導線を追加しました。
- ユーザーが `.json` ファイルを選び、`displayName` / `portraitImage` / `summary` / `tags` を自キャラ表示へ反映できるようにしました。
- JSON未選択時は、既存の固定サンプルRyoで従来通り遊べます。
- 不正なJSONや必要な名前情報がないJSONでは、初心者向けエラーを表示し、現在のキャラを維持します。
- `portraitImage` が空の場合は、画像の代わりに名前の頭文字を表示します。
- 古いサンプル互換として、`displayName` がなく `name` があるJSONでも名前として読めるようにしました。
- HP / 攻撃力 / 移動 / 射程は引き続きサンプルゲーム側の仮ルールで、Passport必須にはしていません。

## 今回やらないこと
- 5人編成
- 敵キャラのPassport読み込み
- パーティJSON読み込み
- GodSandbox本体へのimport機能
- GodSandbox本体のexport機能変更
- Passport schema の大規模変更
- 戦闘ステータスのPassport必須化
- セーブ機能
- オンライン連携
- REST API
- SDK作成
- npm package化
- LLM連携
- 本格タクティクス化
- package変更
- CI workflow変更

## scope外変更がないこと
- 変更は sample-games/passport-paper-battle/ 配下に閉じています。
- src / server / docs / samples / public / package / CI workflow は変更していません。
- GodSandbox内部domain modelには依存していません。

## build / guard / smoke 結果
- node --check sample-games/passport-paper-battle/main.js: 成功
- sample-passport.json JSON parse: 成功
- npm run typecheck: 成功
- npm run build: 成功（Vite の chunk size warning のみ）
- guard: package.json に guard script がないためローカル対象外。GitHub guard確認待ち
- smoke: サーバー/Passport export変更ではないため対象外

## main追従
- git fetch origin 実行済み
- git merge origin/main: Already up to date
- conflictなし

## 後続判断が必要な点
- 次点候補として、敵キャラも画像差し替えできる PBI-PASSPORT-SAMPLE-BATTLE-ENEMY-SKIN-001 を後続で検討できます。