### PR TITLE
fix: Windows batch 起動確認修正

### DIFF
--- a/start-sample-battle.bat
+++ b/start-sample-battle.bat
@@ -7,7 +7,7 @@ cd /d "%REPO_ROOT%"
 
 echo.
 echo =========================================
-echo   Passport Paper Battle 起動スクリプト
+echo   Passport Paper Battle start script
 echo =========================================
 echo repo root: %CD%
 echo.
@@ -24,15 +24,15 @@ if %errorlevel% equ 0 (
 )
 
 if "%PYTHON_CMD%"=="" (
-    echo [エラー] Python が見つかりませんでした。
-    echo サンプル対戦ゲームは file:// ではなくローカルHTTPサーバーで開いてください。
-    echo Python を入れる場合は https://www.python.org/ を確認してください。
+    echo [ERROR] Python was not found.
+    echo Open the sample battle through a local HTTP server, not file://.
+    echo Install Python from https://www.python.org/ and run this script again.
     pause
     exit /b 1
 )
 
-echo サンプル対戦ゲームを起動しています。
-echo ブラウザで http://localhost:8080/sample-games/passport-paper-battle/ を開いてください。
-echo 終了するには Ctrl+C を押してください。
+echo Starting the Passport Paper Battle sample.
+echo Open http://localhost:8080/sample-games/passport-paper-battle/ in your browser.
+echo Press Ctrl+C to stop.
 echo.
 %PYTHON_CMD% -m http.server 8080

--- a/start.bat
+++ b/start.bat
@@ -7,16 +7,15 @@ cd /d "%REPO_ROOT%"
 
 echo.
 echo =========================================
-echo   god-sandbox-mvp 起動スクリプト
+echo   god-sandbox-mvp start script
 echo =========================================
 echo repo root: %CD%
 echo.
 
 node --version > nul 2>&1
 if %errorlevel% neq 0 (
-    echo [エラー] Node.js がインストールされていません。
-    echo ゲームを起動するには Node.js が必要です。
-    echo https://nodejs.org/ からインストールしてください。
+    echo [ERROR] Node.js was not found.
+    echo Install Node.js from https://nodejs.org/ and run this script again.
     pause
     exit /b 1
 )
@@ -24,10 +23,10 @@ if %errorlevel% neq 0 (
 for /f "tokens=*" %%v in ('node --version') do set "NODE_VER=%%v"
 echo [OK] Node.js: %NODE_VER%
 
-npm --version > nul 2>&1
+call npm --version > nul 2>&1
 if %errorlevel% neq 0 (
-    echo [エラー] npm がインストールされていません。
-    echo Node.js を再インストールしてください: https://nodejs.org/
+    echo [ERROR] npm was not found.
+    echo Reinstall Node.js from https://nodejs.org/ and run this script again.
     pause
     exit /b 1
 )
@@ -37,18 +36,18 @@ echo [OK] npm: %NPM_VER%
 echo.
 
 if not exist "node_modules" (
-    echo 依存パッケージをインストールしています... 初回のみ時間がかかります。
-    npm install
+    echo Installing dependencies. This can take a while the first time.
+    call npm install
     if %errorlevel% neq 0 (
-        echo [エラー] npm install が失敗しました。
+        echo [ERROR] npm install failed.
         pause
         exit /b 1
     )
     echo.
 )
 
-echo 育成ゲーム本体を起動しています。
-echo ブラウザで http://localhost:5173 を開いてください。
-echo 終了するには Ctrl+C を押してください。
+echo Starting the main GodSandbox app.
+echo Open http://localhost:5173 in your browser.
+echo Press Ctrl+C to stop.
 echo.
-npm run dev -- --host 0.0.0.0
+call npm run dev -- --host 0.0.0.0


### PR DESCRIPTION
## 対象PBI
PBI-OPS-START-SCRIPTS-PORTABLE-001-FOLLOWUP

Closes #99

## 背景
PR #97 merge後に Windows `.bat` を実際に `cmd.exe` から起動確認したところ、`start.bat` が `npm.cmd` 呼び出し後に batch 本体へ戻らず、dev server 応答前に終了する問題が見つかりました。

## branch
ops/pbi-start-scripts-portable-windows-bat-fix

## 変更ファイル
- `start.bat`
- `start-sample-battle.bat`

## 今回やったこと
- `start.bat` の `npm` 呼び出しを `call npm ...` に変更しました。
- Windows `cmd.exe` での文字化け・誤解釈を避けるため、`.bat` 内の表示文言をASCII中心にしました。
- `start.bat` と `start-sample-battle.bat` を Windows 環境前提で実際に起動確認しました。

## 今回やらないこと
- PowerShell / shell script の追加設計
- README の大幅変更
- アプリ本体の機能変更
- サンプルゲーム本体の機能変更
- package変更
- CI workflow変更
- secret / API key / token の保存

## scope外変更がないこと
- `src/**` は変更していません。
- `server/**` は変更していません。
- `sample-games/passport-paper-battle/main.js` / `index.html` / `style.css` は変更していません。
- `samples/**` は変更していません。
- `package.json` / `package-lock.json` は変更していません。
- `.github/**` は変更していません。

## 確認結果
- `start.bat`: HTTP 200 (`http://localhost:5173/`)
- `start-sample-battle.bat`: HTTP 200 (`http://localhost:8080/sample-games/passport-paper-battle/`)
- 個人パス残存チェック: 残存なし
- `npm run typecheck`: 成功
- `npm run build`: 成功（既存の chunk size warning あり）

## smoke結果
- 対象外（Passport / server export の変更なし）

## 後続判断が必要な点
- なし。Windows `.bat` 起動確認で見つかった範囲の修正です。
