### PR TITLE
chore: WSL向けshell script改行をLF固定

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.bat text eol=crlf


### PR DESCRIPTION
## 対象PBI
PBI-OPS-START-SCRIPTS-WSL-LF-001

Closes #105

## branch
ops/pbi-start-scripts-wsl-lf-001

## 変更ファイル
- `.gitattributes`

## CRLF対策内容
- `*.sh text eol=lf` を追加し、WSL / Linux 用 shell script のLFをGit属性で固定しました。
- `*.bat text eol=crlf` を追加し、Windows batch file のCRLFもGit属性で固定しました。
- `start.sh` / `start-sample-battle.sh` は現行 `origin/main` 時点ですでにLFだったため、`git add --renormalize` しても内容差分は発生しませんでした。

## WSL / Linux系確認結果
- `wsl.exe file start.sh start-sample-battle.sh`: 成功。どちらも `Bourne-Again shell script, Unicode text, UTF-8 text executable` で、`CRLF` 表示なし。
- `wsl.exe bash -n start.sh start-sample-battle.sh`: 成功。
- Git属性確認: `git ls-files --eol` で `start.sh` / `start-sample-battle.sh` が `w/lf attr/text eol=lf`。
- Git属性確認: `start.bat` / `start-sample-battle.bat` が `w/crlf attr/text eol=crlf`。

## 今回やらないこと
- README.md の変更
- `src/**` の変更
- `server/**` の変更
- `sample-games/**` の変更
- `samples/**` の変更
- `package.json` / `package-lock.json` の変更
- `.github/**` の変更
- Windows `.bat` の追加修正
- PowerShell `.ps1` の本格修正
- node_modules の削除や再installの強制

## scope外変更がないこと
- PR diff は `.gitattributes` のみです。
- README変更なし。
- package変更なし。
- CI workflow変更なし。

## 確認結果
- `git diff --name-only HEAD`: `.gitattributes`
- `git diff --check HEAD`: 成功
- `file start.sh start-sample-battle.sh`: 成功、CRLF表示なし
- `bash -n start.sh start-sample-battle.sh`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功（既存の chunk size warning あり）

## smoke結果
- 対象外（Passport / server export / 起動実行の変更なし）

## 後続判断が必要な点
- なし。改行コード管理の固定のみです。
