### PR TITLE
docs: 起動トラブルシューティングを整理する

### DIFF
--- a/docs/startup-troubleshooting.md
+++ b/docs/startup-troubleshooting.md
@@ -8,7 +8,7 @@ PBI-OPS-STARTUP-TROUBLESHOOTING-DOC-001 対応ドキュメント
 
 GodSandbox を Windows / PowerShell / WSL で起動するときに、初心者がつまずきやすい点を短く整理します。
 
-起動スクリプト本体の仕様を変える文書ではありません。  
+起動スクリプト本体の仕様を変える文書ではありません。
 困ったときに「どの起動方法を使えばよいか」「どこを確認すればよいか」を見るための補助資料です。
 
 ---
@@ -29,7 +29,7 @@ PowerShell で起動する場合は `start.ps1` を使います。
 .\start.ps1
 ```
 
-起動中は dev server が動き続けます。  
+起動中は dev server が動き続けます。
 終了するときは、起動したコマンドプロンプトまたは PowerShell の画面で `Ctrl+C` を押してください。
 
 ### サンプル対戦ゲームを起動する
@@ -46,7 +46,7 @@ PowerShell で起動する場合は `start-sample-battle.ps1` を使います。
 .\start-sample-battle.ps1
 ```
 
-サンプル対戦ゲームは、Python HTTP server で開く想定です。  
+サンプル対戦ゲームは、Python HTTP server で開く想定です。
 `file://` で直接 `index.html` を開くと、JSON や画像の読み込みで失敗することがあります。
 
 ---
@@ -72,10 +72,10 @@ WSL で `start.sh` や `start-sample-battle.sh` を実行したときに、次�
 /usr/bin/env: 'bash\r': No such file or directory
 ```
 
-原因は、`.sh` ファイルの改行コードが Windows 向けの CRLF になっていることです。  
+原因は、`.sh` ファイルの改行コードが Windows 向けの CRLF になっていることです。
 WSL / Linux では LF の改行が必要です。
 
-このリポジトリでは、Git 側で `.sh` を LF に固定する方針です。  
+このリポジトリでは、Git 側で `.sh` を LF に固定する方針です。
 もし同じエラーが出る場合は、最新の `main` を取得しているか、`.gitattributes` による LF 固定が反映されているかを確認してください。
 
 ---
@@ -120,7 +120,7 @@ http://localhost:8080/sample-games/passport-paper-battle/
 
 ### Explorer を Task Manager からむやみに終了しない
 
-Windows のフォルダウィンドウは、`explorer.exe` という仕組みで動いています。  
+Windows のフォルダウィンドウは、`explorer.exe` という仕組みで動いています。
 フォルダウィンドウを Task Manager から終了すると、デスクトップやスタートメニューまで一時的に消える場合があります。
 
 その場合は、サインアウトまたは再起動で復旧してください。
@@ -129,7 +129,7 @@ Windows のフォルダウィンドウは、`explorer.exe` という仕組みで
 
 初心者向けの通常手順では、検証ツールなどから hidden window で起動する方法は推奨しません。
 
-画面が見えない状態では、どのサーバーが動いているか、どこで止めればよいか分かりにくくなります。  
+画面が見えない状態では、どのサーバーが動いているか、どこで止めればよいか分かりにくくなります。
 通常は、見えるコマンドプロンプトまたは PowerShell の画面で起動し、終了時は `Ctrl+C` を押してください。
 
 ### 個人パス入りのローカルスクリプトを Git に入れない
@@ -142,7 +142,7 @@ Windows のフォルダウィンドウは、`explorer.exe` という仕組みで
 C:\Users\your-name\...
 ```
 
-このようなファイルは、ほかの人のPCでは動かないことがあります。  
+このようなファイルは、ほかの人のPCでは動かないことがあります。
 Git に入れる前に、個人パスが入っていないか確認してください。
 
 ---

--- a/docs/startup-troubleshooting.md
+++ b/docs/startup-troubleshooting.md
@@ -1,0 +1,172 @@
+# 起動トラブルシューティング
+
+PBI-OPS-STARTUP-TROUBLESHOOTING-DOC-001 対応ドキュメント
+
+---
+
+## この文書の目的
+
+GodSandbox を Windows / PowerShell / WSL で起動するときに、初心者がつまずきやすい点を短く整理します。
+
+起動スクリプト本体の仕様を変える文書ではありません。  
+困ったときに「どの起動方法を使えばよいか」「どこを確認すればよいか」を見るための補助資料です。
+
+---
+
+## まず使う起動方法
+
+### Windows で育成ゲーム本体を起動する
+
+通常は `start.bat` を使います。
+
+```bat
+start.bat
+```
+
+PowerShell で起動する場合は `start.ps1` を使います。
+
+```powershell
+.\start.ps1
+```
+
+起動中は dev server が動き続けます。  
+終了するときは、起動したコマンドプロンプトまたは PowerShell の画面で `Ctrl+C` を押してください。
+
+### サンプル対戦ゲームを起動する
+
+Windows では通常 `start-sample-battle.bat` を使います。
+
+```bat
+start-sample-battle.bat
+```
+
+PowerShell で起動する場合は `start-sample-battle.ps1` を使います。
+
+```powershell
+.\start-sample-battle.ps1
+```
+
+サンプル対戦ゲームは、Python HTTP server で開く想定です。  
+`file://` で直接 `index.html` を開くと、JSON や画像の読み込みで失敗することがあります。
+
+---
+
+## PowerShell 5.1 で `.ps1` が文字化けする場合
+
+Windows 標準の PowerShell 5.1 では、文字コードの扱いによって `.ps1` ファイルが文字化けしたり、`ParseException` が出たりする場合があります。
+
+その場合は、次のどちらかを使ってください。
+
+- `start.bat` を使う
+- PowerShell 7 で `start.ps1` を使う
+
+初心者向けには、まず `start.bat` を使う方法がいちばん分かりやすいです。
+
+---
+
+## WSL で `.sh` が `bash\r` エラーになる場合
+
+WSL で `start.sh` や `start-sample-battle.sh` を実行したときに、次のようなエラーが出ることがあります。
+
+```text
+/usr/bin/env: 'bash\r': No such file or directory
+```
+
+原因は、`.sh` ファイルの改行コードが Windows 向けの CRLF になっていることです。  
+WSL / Linux では LF の改行が必要です。
+
+このリポジトリでは、Git 側で `.sh` を LF に固定する方針です。  
+もし同じエラーが出る場合は、最新の `main` を取得しているか、`.gitattributes` による LF 固定が反映されているかを確認してください。
+
+---
+
+## WSL と Windows で `node_modules` を共有しない
+
+Windows 側で作った `node_modules` を WSL 側でそのまま使うと、Rollup などの optional dependency が壊れることがあります。
+
+Windows と WSL は、同じプロジェクトでも別の実行環境として扱うのが安全です。
+
+WSL で動かす場合は、WSL 側で依存パッケージを入れ直してください。
+
+```bash
+npm install
+```
+
+Windows 側で動かす場合は、Windows 側の Node.js / npm を使ってください。
+
+---
+
+## サンプル対戦ゲームは HTTP で開く
+
+サンプル対戦ゲームは、repo root から HTTP server を起動して開く想定です。
+
+例:
+
+```bash
+python -m http.server 8080
+```
+
+ブラウザでは次を開きます。
+
+```text
+http://localhost:8080/sample-games/passport-paper-battle/
+```
+
+この方法なら、サンプルの JSON や `public/art/...` の画像を読み込みやすくなります。
+
+---
+
+## やってはいけないこと
+
+### Explorer を Task Manager からむやみに終了しない
+
+Windows のフォルダウィンドウは、`explorer.exe` という仕組みで動いています。  
+フォルダウィンドウを Task Manager から終了すると、デスクトップやスタートメニューまで一時的に消える場合があります。
+
+その場合は、サインアウトまたは再起動で復旧してください。
+
+### hidden window で初心者が起動しない
+
+初心者向けの通常手順では、検証ツールなどから hidden window で起動する方法は推奨しません。
+
+画面が見えない状態では、どのサーバーが動いているか、どこで止めればよいか分かりにくくなります。  
+通常は、見えるコマンドプロンプトまたは PowerShell の画面で起動し、終了時は `Ctrl+C` を押してください。
+
+### 個人パス入りのローカルスクリプトを Git に入れない
+
+自分のPCだけで使う起動メモやローカルスクリプトには、個人名や絶対パスが入ることがあります。
+
+例:
+
+```text
+C:\Users\your-name\...
+```
+
+このようなファイルは、ほかの人のPCでは動かないことがあります。  
+Git に入れる前に、個人パスが入っていないか確認してください。
+
+---
+
+## 困ったときの切り分け
+
+| 症状 | まず見ること |
+|---|---|
+| `start.ps1` で文字化けする | `start.bat` を使うか、PowerShell 7 を使う |
+| WSL で `bash\r` と出る | `.sh` の改行コードが LF か確認する |
+| WSL で build が失敗する | WSL 側で `npm install` しているか確認する |
+| サンプル対戦ゲームで画像やJSONが読めない | `file://` ではなく HTTP server で開いているか確認する |
+| デスクトップやスタートメニューが消えた | Explorer が不安定になった可能性があるため、サインアウトまたは再起動する |
+
+---
+
+## このPBIで変更しないもの
+
+- `README.md`
+- 起動スクリプト本体
+- `.gitattributes`
+- `src/**`
+- `server/**`
+- `sample-games/**`
+- `package.json`
+- `package-lock.json`
+- `.github/**`


### PR DESCRIPTION
対象PBI: PBI-OPS-STARTUP-TROUBLESHOOTING-DOC-001
対応Issue: #109
Closes #109
branch: docs/pbi-ops-startup-troubleshooting-doc-001

## 変更ファイル
- docs/startup-troubleshooting.md

## 今回やったこと
- Windows での通常起動方法を整理しました。
  - 通常は start.bat
  - PowerShell では start.ps1
  - 終了は起動した画面で Ctrl+C
- PowerShell 5.1 で .ps1 が文字化け・ParseException になる場合の回避策を整理しました。
  - start.bat を使う
  - PowerShell 7 を使う
- WSL で .sh が bash\r エラーになる原因を整理しました。
  - 原因は CRLF 改行
  - Git 側で LF 固定されているか確認する
- WSL と Windows で node_modules を共有しない方針を整理しました。
- サンプル対戦ゲームは repo root から HTTP server で開くこと、file:// で直接開かないことを整理しました。
- やってはいけないこととして、Explorer の Task Manager 終了、hidden window 起動、個人パス入りローカルスクリプトの混入を短く整理しました。
- PR #103 で README に追記済みの安全注意と矛盾しない内容にしています。

## 今回やらないこと
- README.md の変更
- 起動スクリプト本体の変更
- .gitattributes の変更
- src/** の変更
- server/** の変更
- sample-games/** の変更
- package.json / package-lock.json の変更
- .github/** の変更

## scope外変更がないこと
- PR差分は docs/startup-troubleshooting.md の新規追加だけです。
- README.md は変更していません。
- start.bat / start.ps1 / start.sh / start-sample-battle.* は変更していません。
- package変更、CI変更、コード変更はありません。

## build / guard / smoke 結果
- git diff --name-only origin/main...HEAD: docs/startup-troubleshooting.md のみ
- git diff --check origin/main...HEAD: 成功
- npm run typecheck: 成功
- npm run build: 成功
- smoke: docs-only のため対象外

## 監査役に見てほしい点
- Windows / PowerShell / WSL の起動トラブルが初心者向けに短く整理されているか
- PR #103 の README 安全注意と矛盾していないか
- CodexA が触る .gitattributes / .sh 改行コード修正と競合しないか
- READMEや起動スクリプト本体を変更していないか