### PR TITLE
fix: PowerShell 5.1向けに起動スクリプト表示をASCII化する

### DIFF
--- a/start-sample-battle.ps1
+++ b/start-sample-battle.ps1
@@ -5,7 +5,7 @@ Set-Location -LiteralPath $RepoRoot
 
 Write-Host ""
 Write-Host "========================================="
-Write-Host "  Passport Paper Battle 起動スクリプト"
+Write-Host "  Passport Paper Battle startup"
 Write-Host "========================================="
 Write-Host "repo root: $RepoRoot"
 Write-Host ""
@@ -21,14 +21,14 @@ if (Get-Command python -ErrorAction SilentlyContinue) {
 }
 
 if (-not $PythonCommand) {
-  Write-Host "[エラー] Python が見つかりませんでした。"
-  Write-Host "サンプル対戦ゲームは file:// ではなくローカルHTTPサーバーで開いてください。"
-  Write-Host "Python を入れる場合は https://www.python.org/ を確認してください。"
+  Write-Host "[ERROR] Python was not found."
+  Write-Host "Open the sample battle through a local HTTP server, not file://."
+  Write-Host "Install Python from https://www.python.org/ and try again."
   exit 1
 }
 
-Write-Host "サンプル対戦ゲームを起動しています。"
-Write-Host "ブラウザで http://localhost:8080/sample-games/passport-paper-battle/ を開いてください。"
-Write-Host "終了するには Ctrl+C を押してください。"
+Write-Host "Starting Passport Paper Battle local server."
+Write-Host "Open http://localhost:8080/sample-games/passport-paper-battle/ in your browser."
+Write-Host "Press Ctrl+C to stop."
 Write-Host ""
 & $PythonCommand @PythonArgs -m http.server 8080

--- a/start.ps1
+++ b/start.ps1
@@ -5,15 +5,14 @@ Set-Location -LiteralPath $RepoRoot
 
 Write-Host ""
 Write-Host "========================================="
-Write-Host "  god-sandbox-mvp 起動スクリプト"
+Write-Host "  god-sandbox-mvp startup"
 Write-Host "========================================="
 Write-Host "repo root: $RepoRoot"
 Write-Host ""
 
 if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
-  Write-Host "[エラー] Node.js がインストールされていません。"
-  Write-Host "ゲームを起動するには Node.js が必要です。"
-  Write-Host "https://nodejs.org/ からインストールしてください。"
+  Write-Host "[ERROR] Node.js is not installed."
+  Write-Host "Install Node.js from https://nodejs.org/ and try again."
   exit 1
 }
 
@@ -25,8 +24,8 @@ if (-not $NpmCommand) {
 }
 
 if (-not $NpmCommand) {
-  Write-Host "[エラー] npm がインストールされていません。"
-  Write-Host "Node.js を再インストールしてください: https://nodejs.org/"
+  Write-Host "[ERROR] npm is not installed."
+  Write-Host "Reinstall Node.js from https://nodejs.org/ and try again."
   exit 1
 }
 
@@ -34,13 +33,13 @@ Write-Host "[OK] npm: $(& $NpmCommand.Source --version)"
 Write-Host ""
 
 if (-not (Test-Path -LiteralPath "node_modules" -PathType Container)) {
-  Write-Host "依存パッケージをインストールしています... 初回のみ時間がかかります。"
+  Write-Host "Installing dependencies... This may take a while on the first run."
   & $NpmCommand.Source install
   Write-Host ""
 }
 
-Write-Host "育成ゲーム本体を起動しています。"
-Write-Host "ブラウザで http://localhost:5173 を開いてください。"
-Write-Host "終了するには Ctrl+C を押してください。"
+Write-Host "Starting GodSandbox development server."
+Write-Host "Open http://localhost:5173 in your browser."
+Write-Host "Press Ctrl+C to stop."
 Write-Host ""
 & $NpmCommand.Source run dev -- --host 0.0.0.0


### PR DESCRIPTION
対象PBI: PBI-OPS-START-PS1-POWERSHELL51-ENCODING-001
対応Issue: #141
Closes #141
branch: fix/pbi-start-ps1-powershell51-encoding-001

## 変更ファイル
- start.ps1
- start-sample-battle.ps1

## 今回やったこと
- Windows PowerShell 5.1 で文字化け由来の ParseException が起きないよう、`.ps1` 内の表示文言を ASCII 中心へ変更しました。
- 起動スクリプトの処理フローは変えず、表示メッセージのみを安全側へ寄せました。
- `start-sample-battle.ps1` も同じ方針で ASCII 表示へ揃えました。

## 今回やらないこと
- src / server / sample-games の変更
- package変更
- CI workflow変更
- .bat / .sh の変更
- PowerShell 実行ポリシーやローカル環境設定の変更

## scope外変更がないこと
- 変更は `start.ps1` / `start-sample-battle.ps1` の2ファイルのみです。

## 確認結果
- `git diff --name-only`: `start.ps1`, `start-sample-battle.ps1` のみ
- `git diff --check`: 成功（GitのCRLF通知のみ）
- PowerShell 5.1 parser check `start.ps1`: 成功
- PowerShell 5.1 parser check `start-sample-battle.ps1`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功（chunk size warningのみ）

## 監査役に見てほしい点
- PowerShell 5.1 向けの文字化け回避として十分か
- 起動処理そのものを変えていないか
- scope外変更が混ざっていないか