### PR TITLE
feat: 箱庭ガイドを薄い折りたたみバーへ変更する

### DIFF
--- a/src/features/sandbox/WorldViewport.tsx
+++ b/src/features/sandbox/WorldViewport.tsx
@@ -326,7 +326,7 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
   }, [characters, focusCharacterId, paused]);
 
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if ((event.target as HTMLElement).closest(".viewport-overlay__controls")) {
+    if ((event.target as HTMLElement).closest(".viewport-overlay__controls, .world-viewport-guide")) {
       return;
     }
     dragStateRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
@@ -387,33 +387,27 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
           <span>金</span>
           <span>水</span>
         </div>
-        <section className="world-viewport-guide" aria-label="箱庭ガイド">
-          <div className="world-viewport-guide__eyebrow">Sandbox Guide</div>
-          <h2 className="world-viewport-guide__title">ここが箱庭です</h2>
-          <p className="world-viewport-guide__text">{guideSummary}</p>
-          <div className="world-viewport-guide__stats" aria-label="箱庭の現在地">
-            <div className="world-viewport-guide__stat">
-              <span className="world-viewport-guide__stat-label">キャラ</span>
-              <strong className="world-viewport-guide__stat-value">{totalCharacters}</strong>
+        <details className="world-viewport-guide" aria-label="箱庭ガイド">
+          <summary className="world-viewport-guide__bar">
+            <span className="world-viewport-guide__eyebrow">Sandbox Guide</span>
+            <span className="world-viewport-guide__chip">ここが箱庭</span>
+            <span className="world-viewport-guide__chip">ドラッグで見回す</span>
+            <span className="world-viewport-guide__chip">光る人物を追う</span>
+            <span className="world-viewport-guide__expand">詳しく見る</span>
+          </summary>
+          <div className="world-viewport-guide__panel">
+            <h2 className="world-viewport-guide__title">箱庭の見方</h2>
+            <p className="world-viewport-guide__text">{guideSummary}</p>
+            <div className="world-viewport-guide__mini-stats" aria-label="箱庭の現在地">
+              <span>全員 {totalCharacters}</span>
+              <span>生存 {livingCount}</span>
+              <span>変化 {noteworthyCount}</span>
             </div>
-            <div className="world-viewport-guide__stat">
-              <span className="world-viewport-guide__stat-label">生存中</span>
-              <strong className="world-viewport-guide__stat-value">{livingCount}</strong>
-            </div>
-            <div className="world-viewport-guide__stat">
-              <span className="world-viewport-guide__stat-label">気になる変化</span>
-              <strong className="world-viewport-guide__stat-value">{noteworthyCount}</strong>
-            </div>
+            <p className="world-viewport-guide__focus">いま見る: {focusLabel}</p>
+            <div className="world-viewport-guide__cta">{nextAction}</div>
+            <p className="world-viewport-guide__state">今の気配: {omen}</p>
           </div>
-          <p className="world-viewport-guide__focus">いま見る: {focusLabel}</p>
-          <div className="world-viewport-guide__steps" aria-label="箱庭の見方">
-            <span className="world-viewport-guide__step">ドラッグで見回す</span>
-            <span className="world-viewport-guide__step">光るリングの人物を追う</span>
-            <span className="world-viewport-guide__step">変化が起きたら観察する</span>
-          </div>
-          <div className="world-viewport-guide__cta">{nextAction}</div>
-          <p className="world-viewport-guide__state">今の気配: {omen}</p>
-        </section>
+        </details>
         <div className="viewport-overlay__controls">
           <div className="viewport-overlay__chip viewport-overlay__chip--controls">
             視点 {cameraMode === "follow" ? `自動追従 / ${focusTarget?.name ?? "対象なし"}` : "自由視点"}

--- a/src/features/sandbox/WorldViewportGuide.css
+++ b/src/features/sandbox/WorldViewportGuide.css
@@ -1,19 +1,33 @@
 .world-viewport-guide {
   position: absolute;
-  left: 1rem;
+  right: 1rem;
   bottom: 1rem;
-  width: min(24rem, calc(100% - 2rem));
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
+  left: 1rem;
+  z-index: 2;
   border: 1px solid rgba(121, 176, 154, 0.3);
-  border-radius: 18px;
+  border-radius: 999px;
   background:
-    linear-gradient(180deg, rgba(8, 18, 23, 0.95), rgba(18, 35, 41, 0.86)),
-    rgba(8, 18, 23, 0.9);
-  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.26);
-  padding: 0.9rem 1rem;
+    linear-gradient(180deg, rgba(8, 18, 23, 0.9), rgba(18, 35, 41, 0.78)),
+    rgba(8, 18, 23, 0.82);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
   color: #edf5f0;
+}
+
+.world-viewport-guide[open] {
+  border-radius: 18px;
+}
+
+.world-viewport-guide__bar {
+  display: flex;
+  min-height: 2.65rem;
+  align-items: center;
+  gap: 0.45rem;
+  list-style: none;
+  padding: 0.45rem 0.7rem;
+}
+
+.world-viewport-guide__bar::-webkit-details-marker {
+  display: none;
 }
 
 .world-viewport-guide__eyebrow {
@@ -24,9 +38,45 @@
   text-transform: uppercase;
 }
 
+.world-viewport-guide__chip,
+.world-viewport-guide__expand {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.34rem 0.58rem;
+  color: #deebe6;
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+
+.world-viewport-guide__expand {
+  margin-left: auto;
+  border: 1px solid rgba(111, 207, 151, 0.3);
+  background: rgba(111, 207, 151, 0.14);
+  color: #effaf3;
+  font-weight: 700;
+}
+
+.world-viewport-guide[open] .world-viewport-guide__expand {
+  color: transparent;
+  font-size: 0;
+}
+
+.world-viewport-guide[open] .world-viewport-guide__expand::after {
+  content: "閉じる";
+  color: #effaf3;
+  font-size: 0.74rem;
+}
+
+.world-viewport-guide__panel {
+  display: grid;
+  gap: 0.55rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.2rem 0.9rem 0.9rem;
+}
+
 .world-viewport-guide__title {
   margin: 0;
-  font-size: 1.08rem;
+  font-size: 1rem;
   line-height: 1.2;
 }
 
@@ -35,7 +85,7 @@
 .world-viewport-guide__state {
   margin: 0;
   color: #d4e4de;
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   line-height: 1.45;
 }
 
@@ -49,41 +99,13 @@
   font-size: 0.76rem;
 }
 
-.world-viewport-guide__stats {
-  display: grid;
-  gap: 0.45rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.world-viewport-guide__stat {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 0.22rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.05);
-  padding: 0.55rem 0.6rem;
-}
-
-.world-viewport-guide__stat-label {
-  color: #9ec0b0;
-  font-size: 0.7rem;
-}
-
-.world-viewport-guide__stat-value {
-  color: #f4fbf7;
-  font-size: 1rem;
-  line-height: 1.15;
-}
-
-.world-viewport-guide__steps {
+.world-viewport-guide__mini-stats {
   display: flex;
   flex-wrap: wrap;
   gap: 0.38rem;
 }
 
-.world-viewport-guide__step {
+.world-viewport-guide__mini-stats span {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   padding: 0.35rem 0.6rem;
@@ -118,7 +140,6 @@
     right: 0.75rem;
     bottom: 0.75rem;
     width: auto;
-    padding: 0.8rem 0.85rem;
   }
 }
 
@@ -128,6 +149,10 @@
   }
 
   .world-viewport--guided .viewport-overlay__legend {
+    display: none;
+  }
+
+  .world-viewport--guided .viewport-overlay__chip--center {
     display: none;
   }
 
@@ -144,26 +169,37 @@
     min-width: 0;
   }
 
+  .world-viewport-guide {
+    bottom: 0.55rem;
+  }
+
+  .world-viewport-guide__bar {
+    gap: 0.32rem;
+    overflow-x: auto;
+    padding: 0.4rem 0.55rem;
+    scrollbar-width: none;
+  }
+
+  .world-viewport-guide__bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .world-viewport-guide__eyebrow {
+    display: none;
+  }
+
+  .world-viewport-guide__chip,
+  .world-viewport-guide__expand {
+    font-size: 0.7rem;
+  }
+
   .world-viewport-guide__title {
-    font-size: 1rem;
+    font-size: 0.95rem;
   }
 
   .world-viewport-guide__text,
   .world-viewport-guide__focus {
     font-size: 0.8rem;
-  }
-
-  .world-viewport-guide__stats {
-    gap: 0.35rem;
-  }
-
-  .world-viewport-guide__stat {
-    padding: 0.5rem 0.55rem;
-  }
-
-  .world-viewport-guide__step {
-    width: 100%;
-    text-align: center;
   }
 
   .world-viewport-guide__cta {


### PR DESCRIPTION
対象PBI: PBI-MOBILE-WORLD-VIEWPORT-GUIDE-BAR-001
対応Issue: #143
Closes #143
branch: mobile/pbi-mobile-world-viewport-guide-bar-001

## 変更ファイル
- src/features/sandbox/WorldViewport.tsx
- src/features/sandbox/WorldViewportGuide.css

## 今回やったこと
- 大きな `SANDBOX GUIDE` を、箱庭下端の薄い折りたたみガイドバーへ変更しました。
- 閉じた状態では「ここが箱庭」「ドラッグで見回す」「光る人物を追う」の短いチップだけを表示します。
- 詳細は `details` の展開時だけ表示し、stats / focus / 次アクション / chaos omen は補助情報として残しました。
- スマホ幅では中央や上部を占有しないようにし、3D箱庭を主役に戻しました。
- ガイド操作時にドラッグ開始しないよう、pointer down の除外対象に `.world-viewport-guide` を追加しました。

## 今回やらないこと
- 初回導入画面の追加
- FirstActionGuide の変更
- EventModal の変更
- ゲームロジック変更
- package変更
- CI変更
- Passport schema変更
- PWA / Capacitor / native対応

## scope外変更なし
- 変更は許可された2ファイルに閉じています。
- src/app/AppShell.tsx / src/features/onboarding / src/features/events / src/index.css / docs / server / sample-games / package / CI workflow は変更していません。

## 確認コマンドと結果
- `git diff --name-only origin/main...HEAD`: 許可2ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
  - 既存の chunk size warning は出ていますが、今回のPBI範囲外として未対応です。

## 監査役に見てほしい点
- iPhone Safari 縦持ち相当で3D箱庭がガイドに大きく隠れない構成になっているか
- 初見でも「箱庭を見回す」ことが短く分かるか
- desktop表示で情報量が過度に減っていないか
- 既存のカメラ操作、ドラッグ、ズーム、フォーカス復帰を壊していないか
- `src/index.css` や AppShell / onboarding / events に触れていないか
