### PR TITLE
ux: 初回CTAを短く明確にする

### DIFF
--- a/src/features/onboarding/FirstActionGuide.css
+++ b/src/features/onboarding/FirstActionGuide.css
@@ -1,19 +1,20 @@
 .first-action-guide {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  gap: 0.9rem;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
   border: 1px solid rgba(255, 218, 145, 0.24);
   border-radius: 22px;
   background:
     radial-gradient(circle at top left, rgba(255, 218, 145, 0.16), transparent 34%),
     linear-gradient(135deg, rgba(35, 51, 69, 0.96), rgba(14, 24, 35, 0.92));
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.24);
-  padding: 1rem;
+  padding: 0.95rem;
 }
 
 .first-action-guide__copy {
   display: grid;
-  gap: 0.55rem;
+  align-content: center;
+  gap: 0.45rem;
 }
 
 .first-action-guide__eyebrow,
@@ -33,20 +34,20 @@
 
 .first-action-guide h2 {
   color: #f7fbff;
-  font-size: clamp(1.2rem, 3vw, 1.8rem);
-  line-height: 1.25;
+  font-size: clamp(1.14rem, 2.7vw, 1.58rem);
+  line-height: 1.24;
 }
 
 .first-action-guide__copy p {
   max-width: 62rem;
   color: #c9d6e4;
-  line-height: 1.72;
+  line-height: 1.62;
 }
 
 .first-action-guide__action-card {
   display: grid;
   align-content: center;
-  gap: 0.75rem;
+  gap: 0.7rem;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.08);
@@ -59,7 +60,10 @@
   border-radius: 16px;
   background: linear-gradient(135deg, #f4b557, #df6f3d);
   color: #101923;
+  cursor: pointer;
+  font-size: 1.02rem;
   font-weight: 800;
+  min-height: 3.35rem;
   padding: 0.95rem 1rem;
   text-align: center;
   box-shadow: 0 12px 24px rgba(223, 111, 61, 0.22);
@@ -75,6 +79,8 @@
 }
 
 .first-action-guide__cta--notice {
+  display: grid;
+  place-items: center;
   cursor: default;
 }
 
@@ -91,12 +97,13 @@
     padding: 0.85rem;
   }
 
-  .first-action-guide__action-card {
-    order: 2;
+  .first-action-guide__cta {
+    min-height: 3.6rem;
+    font-size: 1.05rem;
   }
 
-  .first-action-guide__cta {
-    min-height: 3.2rem;
-    font-size: 1rem;
+  .first-action-guide__copy p {
+    font-size: 0.94rem;
+    line-height: 1.58;
   }
 }

--- a/src/features/onboarding/FirstActionGuide.tsx
+++ b/src/features/onboarding/FirstActionGuide.tsx
@@ -17,41 +17,36 @@ export function FirstActionGuide({
 }: FirstActionGuideProps) {
   const isEventOpen = phase === "event";
   const canStep = hasLivingCharacters && !isEventOpen;
-  const guideStatus = getGuideStatus({ hasLivingCharacters, isEventOpen, tick, timeControl });
+  const guide = getGuideState({ hasLivingCharacters, isEventOpen, tick, timeControl });
 
   return (
     <section className="first-action-guide" aria-labelledby="first-action-guide-title">
       <div className="first-action-guide__copy">
-        <p className="first-action-guide__eyebrow">はじめての神様へ</p>
-        <h2 id="first-action-guide-title">箱庭を見守り、重要イベントで運命に介入するゲームです</h2>
+        <p className="first-action-guide__eyebrow">まずはここから</p>
+        <h2 id="first-action-guide-title">AIキャラを見守り、変化が起きたらどう関わるか選ぶゲームです</h2>
         <p>
-          まずは時間を1 tick進めて、キャラクターたちの変化を観察します。
-          大きな出来事が起きたら、神として加護や試練を選び、物語の流れを変えます。
+          最初はむずかしい設定を覚えなくて大丈夫です。下の大きなボタンから、箱庭の時間を少しだけ進めましょう。
         </p>
       </div>
 
       <div className="first-action-guide__action-card" aria-label="次にすること">
-        <span className="first-action-guide__status">{guideStatus}</span>
+        <span className="first-action-guide__status">{guide.status}</span>
         {isEventOpen ? (
           <div className="first-action-guide__cta first-action-guide__cta--notice">
-            イベントで介入を選ぶ
+            {guide.ctaLabel}
           </div>
         ) : (
           <button className="first-action-guide__cta" type="button" disabled={!canStep} onClick={onStepTick}>
-            まず1 tick進める
+            {guide.ctaLabel}
           </button>
         )}
-        <p className="first-action-guide__hint">
-          {isEventOpen
-            ? "時間は止まっています。表示中のイベントで、キャラにどう関わるかを選びましょう。"
-            : "慣れてきたら、上の「通常」で自動観察に切り替えられます。"}
-        </p>
+        <p className="first-action-guide__hint">{guide.hint}</p>
       </div>
     </section>
   );
 }
 
-function getGuideStatus({
+function getGuideState({
   hasLivingCharacters,
   isEventOpen,
   tick,
@@ -63,20 +58,40 @@ function getGuideStatus({
   timeControl: "stopped" | "slow" | "normal";
 }) {
   if (!hasLivingCharacters) {
-    return "現在地: 生存者がいません";
+    return {
+      status: "現在地: キャラを準備中",
+      ctaLabel: "キャラを準備中",
+      hint: "キャラクターが現れたら、ここから観察を始められます。",
+    };
   }
 
   if (isEventOpen) {
-    return "現在地: 重要イベント発生中";
+    return {
+      status: "現在地: 出来事が発生中",
+      ctaLabel: "起きた出来事を見る",
+      hint: "表示中の出来事カードで、キャラにどう関わるかを選びましょう。",
+    };
   }
 
   if (tick === 0) {
-    return "現在地: 観察開始前";
+    return {
+      status: "現在地: 観察開始前",
+      ctaLabel: "少し時間を進める",
+      hint: "まずは一度だけ進めて、キャラの変化を見てみましょう。",
+    };
   }
 
   if (timeControl === "stopped") {
-    return `現在地: tick ${tick} / 停止中`;
+    return {
+      status: "現在地: 観察を一時停止中",
+      ctaLabel: "少し時間を進める",
+      hint: "もう一度だけ進めると、次の変化を確認できます。",
+    };
   }
 
-  return `現在地: tick ${tick} / 観察中`;
+  return {
+    status: "現在地: 観察中",
+    ctaLabel: "変化を追う",
+    hint: "自動で進んでいます。気になる変化が出たら、画面の案内に沿って選びます。",
+  };
 }


### PR DESCRIPTION
対象PBI: PBI-UX-FIRST-ACTION-CTA-SIMPLIFY-001
対応Issue: #144
Closes #144
branch: ux/pbi-first-action-cta-simplify-001

## 変更ファイル
- src/features/onboarding/FirstActionGuide.tsx
- src/features/onboarding/FirstActionGuide.css

## 今回やったこと
- FirstActionGuide の説明を「AIキャラを見守り、変化が起きたらどう関わるか選ぶゲームです」という短い1文に整理しました。
- 初回の主要CTAを1つだけ目立つ形に維持しました。
- 初見向け表示から `1 tick` / `tick` の文言を外し、「少し時間を進める」に言い換えました。
- 「介入」を「どう関わるか選ぶ」に言い換えました。
- 状態別CTAを整理しました。
  - 観察開始前: `少し時間を進める`
  - 観察中: `変化を追う`
  - イベント中: `起きた出来事を見る`
- スマホでCTAが押しやすいよう、CTAの高さと文字サイズを調整しました。
- 長文カードになりすぎないよう、説明文を短くしました。

## 今回やらないこと
- SANDBOX GUIDE の変更
- EventModal の変更
- 初回専用導入画面の追加
- ゲームロジック変更
- package変更
- CI変更
- Passport schema変更
- `src/index.css` 変更
- `docs/**` 変更

## scope外変更がないこと
- 変更は `src/features/onboarding/FirstActionGuide.tsx` と `src/features/onboarding/FirstActionGuide.css` のみに閉じています。
- `src/features/sandbox/**`、`src/features/events/**`、`src/index.css` は変更していません。
- `server/**`、`sample-games/**`、`samples/**`、package、CI workflow、起動スクリプトは変更していません。

## 確認コマンドと結果
- `git diff --name-only origin/main...HEAD`: 許可ファイル2件のみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功（既存の chunk size warning あり）

補足: `npm run build` は sandbox 内で esbuild spawn が `EPERM` になったため、通常権限で再実行して成功しています。

## 監査役に見てほしい点
- 初見でも「何のゲームか」が短い1文で分かるか
- 主要CTAが1つだけ明確に見えるか
- 初回CTAから `tick` などの専門語が消えているか
- スマホでCTAが押しやすいサイズになっているか
- `src/index.css` やイベント・サンドボックス側へscopeが広がっていないか
