### PR TITLE
fix: SANDBOX GUIDEの詳しく見るをクリック可能にする

### DIFF
--- a/src/features/sandbox/WorldViewportGuide.css
+++ b/src/features/sandbox/WorldViewportGuide.css
@@ -4,6 +4,7 @@
   bottom: 1rem;
   left: 1rem;
   z-index: 2;
+  pointer-events: auto;
   border: 1px solid rgba(121, 176, 154, 0.3);
   border-radius: 999px;
   background:


### PR DESCRIPTION
対象PBI: PBI-MOBILE-WORLD-VIEWPORT-GUIDE-CLICK-001
対応Issue: #149
Closes #149
branch: fix-world-viewport-guide-click-001

## 変更ファイル
- src/features/sandbox/WorldViewportGuide.css

## 今回やったこと
- `.world-viewport-guide` に `pointer-events: auto` を追加しました。
- `viewport-overlay` の `pointer-events: none` によって「詳しく見る」クリックが透過していた問題を修正しました。

## 今回やらないこと
- レイアウト再設計
- `WorldViewport.tsx` の変更
- `src/index.css` の変更
- package変更
- CI変更

## scope外変更がないこと
- 変更は `src/features/sandbox/WorldViewportGuide.css` の1ファイルのみです。

## 確認結果
- `git diff --name-only`: `src/features/sandbox/WorldViewportGuide.css` のみ
- `git diff --check`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功（既存の chunk size warning のみ）

## 監査役に見てほしい点
- `SANDBOX GUIDE` の details/summary がクリック可能になる修正として十分か
- `viewport-overlay__controls` と同じ pointer-events 方針になっているか
- scope外変更がないか