### PR TITLE
fix: iOS Safariの箱庭ドラッグ競合を抑える

### DIFF
--- a/src/features/sandbox/WorldViewport.tsx
+++ b/src/features/sandbox/WorldViewport.tsx
@@ -329,6 +329,7 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
     if ((event.target as HTMLElement).closest(".viewport-overlay__controls, .world-viewport-guide")) {
       return;
     }
+    event.preventDefault();
     dragStateRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
     event.currentTarget.setPointerCapture(event.pointerId);
   };
@@ -339,6 +340,7 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
       return;
     }
 
+    event.preventDefault();
     const deltaX = event.clientX - dragState.x;
     const deltaY = event.clientY - dragState.y;
     dragStateRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };

--- a/src/features/sandbox/WorldViewportGuide.css
+++ b/src/features/sandbox/WorldViewportGuide.css
@@ -1,3 +1,16 @@
+.world-viewport--guided,
+.world-viewport--guided .viewport-root__canvas,
+.world-viewport--guided canvas {
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.world-viewport--guided .viewport-overlay__controls,
+.world-viewport-guide {
+  touch-action: manipulation;
+}
+
 .world-viewport-guide {
   position: absolute;
   right: 1rem;


### PR DESCRIPTION
対象PBI: PBI-MOBILE-IOS-VIEWPORT-GESTURE-FIX-001
対応Issue: #151
Closes #151
branch: fix/pbi-mobile-ios-viewport-gesture-fix-001

## 変更ファイル
- src/features/sandbox/WorldViewport.tsx
- src/features/sandbox/WorldViewportGuide.css

## 今回やったこと
- viewport / canvas 領域に `touch-action: none` を適用し、箱庭上のタッチドラッグがページスクロールに奪われにくいようにしました。
- `pointerdown` / `pointermove` のドラッグ中に `preventDefault()` を呼び、iOS Safari のページパン/スクロール競合を抑えました。
- ガイドバーとズーム/フォーカス操作には `touch-action: manipulation` を適用し、タップ可能なUI部品として維持しました。
- viewport外のページスクロールには触れていません。

## 今回やらないこと
- カメラ操作UIの大改修
- ガイド文言変更
- チュートリアル追加
- ゲームロジック変更
- package変更
- CI変更

## scope外変更なし
- 変更は許可された2ファイルに閉じています。
- src/features/onboarding / src/features/events / src/app/AppShell.tsx / server / sample-games / docs / package / CI workflow は変更していません。
- src/index.css は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 許可2ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
  - 既存の chunk size warning は出ていますが、今回のPBI範囲外として未対応です。

## iOS実機確認が必要な点
- iPhone Safari 縦持ちで、箱庭上の左右ドラッグがページパンに奪われにくいこと
- iPhone Safari 縦持ちで、箱庭上の上下ドラッグがページスクロールに奪われにくいこと
- 箱庭外では通常スクロールできること
- ガイドバー、ズーム、フォーカスボタンがタップ可能なこと

## 監査役に見てほしい点
- viewport内の gesture 抑制が、UI部品のタップ操作を壊していないか
- desktop のドラッグ操作に影響がないか
- `src/index.css` へ広げず component-local CSS に閉じているか
