### PR TITLE
feat: add apostle guided first action overlay

### DIFF
--- a/src/features/onboarding/FirstActionGuide.css
+++ b/src/features/onboarding/FirstActionGuide.css
@@ -44,6 +44,49 @@
   line-height: 1.62;
 }
 
+.first-action-guide__apostle {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  border: 1px solid rgba(255, 218, 145, 0.2);
+  border-radius: 16px;
+  background: rgba(255, 218, 145, 0.1);
+  padding: 0.65rem 0.72rem;
+}
+
+.first-action-guide__apostle p {
+  color: #f0e4c7;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.first-action-guide__apostle-mark {
+  border-radius: 999px;
+  background: rgba(255, 218, 145, 0.18);
+  color: #ffd991;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0.34rem 0.54rem;
+}
+
+.first-action-guide__dismiss {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #d8e4ef;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.42rem 0.62rem;
+  white-space: nowrap;
+}
+
+.first-action-guide__dismiss:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
 .first-action-guide__action-card {
   display: grid;
   align-content: center;
@@ -52,6 +95,25 @@
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.08);
   padding: 0.9rem;
+}
+
+.first-action-guide__action-card--highlight {
+  position: relative;
+  box-shadow:
+    0 0 0 1px rgba(255, 218, 145, 0.18),
+    0 0 32px rgba(244, 181, 87, 0.16);
+}
+
+.first-action-guide__action-card--highlight::before {
+  content: "次に押す場所";
+  justify-self: start;
+  border-radius: 999px;
+  background: rgba(244, 181, 87, 0.14);
+  color: #ffd991;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0.28rem 0.54rem;
 }
 
 .first-action-guide__cta {
@@ -105,5 +167,16 @@
   .first-action-guide__copy p {
     font-size: 0.94rem;
     line-height: 1.58;
+  }
+
+  .first-action-guide__apostle {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    padding: 0.62rem;
+  }
+
+  .first-action-guide__apostle-mark,
+  .first-action-guide__dismiss {
+    justify-self: start;
   }
 }

--- a/src/features/onboarding/FirstActionGuide.tsx
+++ b/src/features/onboarding/FirstActionGuide.tsx
@@ -1,4 +1,31 @@
+import { useEffect, useState } from "react";
 import "./FirstActionGuide.css";
+
+const TUTORIAL_DISMISSED_KEY = "godsandbox.apostleTutorialGuide.dismissed.v1";
+
+function readTutorialDismissed() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(TUTORIAL_DISMISSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeTutorialDismissed() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(TUTORIAL_DISMISSED_KEY, "true");
+  } catch {
+    // 保存できない環境でも案内自体は使えるため、次回再表示だけ許容します。
+  }
+}
 
 interface FirstActionGuideProps {
   hasLivingCharacters: boolean;
@@ -18,18 +45,42 @@ export function FirstActionGuide({
   const isEventOpen = phase === "event";
   const canStep = hasLivingCharacters && !isEventOpen;
   const guide = getGuideState({ hasLivingCharacters, isEventOpen, tick, timeControl });
+  const [isTutorialDismissed, setIsTutorialDismissed] = useState(readTutorialDismissed);
+
+  useEffect(() => {
+    if (!isTutorialDismissed) {
+      return;
+    }
+
+    writeTutorialDismissed();
+  }, [isTutorialDismissed]);
 
   return (
     <section className="first-action-guide" aria-labelledby="first-action-guide-title">
       <div className="first-action-guide__copy">
-        <p className="first-action-guide__eyebrow">まずはここから</p>
-        <h2 id="first-action-guide-title">AIキャラを見守り、変化が起きたらどう関わるか選ぶゲームです</h2>
+        <p className="first-action-guide__eyebrow">使徒の案内</p>
+        <h2 id="first-action-guide-title">ここはAIキャラが暮らす箱庭です</h2>
         <p>
-          最初はむずかしい設定を覚えなくて大丈夫です。下の大きなボタンから、箱庭の時間を少しだけ進めましょう。
+          神様として世界を見守り、変化が起きたらキャラにどう関わるかを選びます。
         </p>
+        {!isTutorialDismissed ? (
+          <div className="first-action-guide__apostle" role="note" aria-label="使徒からの短い案内">
+            <span className="first-action-guide__apostle-mark" aria-hidden="true">
+              使徒
+            </span>
+            <p>{guide.apostleLine}</p>
+            <button
+              className="first-action-guide__dismiss"
+              type="button"
+              onClick={() => setIsTutorialDismissed(true)}
+            >
+              あとで見る
+            </button>
+          </div>
+        ) : null}
       </div>
 
-      <div className="first-action-guide__action-card" aria-label="次にすること">
+      <div className="first-action-guide__action-card first-action-guide__action-card--highlight" aria-label="次にすること">
         <span className="first-action-guide__status">{guide.status}</span>
         {isEventOpen ? (
           <div className="first-action-guide__cta first-action-guide__cta--notice">
@@ -62,6 +113,7 @@ function getGuideState({
       status: "現在地: キャラを準備中",
       ctaLabel: "キャラを準備中",
       hint: "キャラクターが現れたら、ここから観察を始められます。",
+      apostleLine: "まずは箱庭にキャラが現れるのを待ちましょう。準備ができたら、次の一手を案内します。",
     };
   }
 
@@ -70,6 +122,7 @@ function getGuideState({
       status: "現在地: 出来事が発生中",
       ctaLabel: "起きた出来事を見る",
       hint: "表示中の出来事カードで、キャラにどう関わるかを選びましょう。",
+      apostleLine: "出来事が起きました。カードを見て、このキャラにどう関わるか選びましょう。",
     };
   }
 
@@ -78,6 +131,7 @@ function getGuideState({
       status: "現在地: 観察開始前",
       ctaLabel: "少し時間を進める",
       hint: "まずは一度だけ進めて、キャラの変化を見てみましょう。",
+      apostleLine: "最初に押すのは、この大きなボタンだけで大丈夫です。箱庭が少し動きます。",
     };
   }
 
@@ -86,6 +140,7 @@ function getGuideState({
       status: "現在地: 観察を一時停止中",
       ctaLabel: "少し時間を進める",
       hint: "もう一度だけ進めると、次の変化を確認できます。",
+      apostleLine: "よく見えました。もう少しだけ進めて、次の変化を追ってみましょう。",
     };
   }
 
@@ -93,5 +148,6 @@ function getGuideState({
     status: "現在地: 観察中",
     ctaLabel: "変化を追う",
     hint: "自動で進んでいます。気になる変化が出たら、画面の案内に沿って選びます。",
+    apostleLine: "世界は動いています。大事な出来事が起きたら、私が知らせます。",
   };
 }


### PR DESCRIPTION
対象PBI: PBI-TUTORIAL-APOSTLE-GUIDED-OVERLAY-001
対応Issue: #162
Closes #162
branch: feature/pbi-tutorial-apostle-guided-overlay-001

## 変更ファイル
- src/features/onboarding/FirstActionGuide.tsx
- src/features/onboarding/FirstActionGuide.css

## 使徒チュートリアル導線の概要
- 初回ユーザー向けに「ここはAIキャラが暮らす箱庭です」と短く説明する使徒案内を追加しました。
- 最初のゲーム操作は既存の「少し時間を進める」CTA 1つに絞ったままにしています。
- 状態に応じて、観察開始前、観察中、出来事発生中の短い使徒セリフを切り替えます。
- `localStorage` キー `godsandbox.apostleTutorialGuide.dismissed.v1` で「あとで見る」を保存し、再訪時に案内が毎回出すぎないようにしました。

## ハイライト対象
- FirstActionGuide 内の次アクションカードと主要CTAをハイライト対象にしました。
- 画面全体のoverlayではなく、既存カード内の軽いハイライトに留め、スマホで3D箱庭を大きく隠さない方針です。

## 今回やらないこと
- domain event 追加
- Bless結果処理
- 神様ポイント実装
- EventModal改修
- WorldViewport改修
- 使徒画像アセット追加
- package変更
- CI変更

## scope外変更がないこと
- 変更は `src/features/onboarding/FirstActionGuide.tsx` と `src/features/onboarding/FirstActionGuide.css` のみに閉じています。
- `src/domain/**`、`src/features/events/**`、`src/features/sandbox/**`、`src/features/apostle/**`、`src/app/AppShell.tsx`、`src/index.css`、`docs/**`、`public/**`、`sample-games/**`、package、CI workflow は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 許可ファイル2件のみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
  - 通常実行時にVite/esbuildの `spawn EPERM` が出たため、同じコマンドを権限付きで再実行して成功を確認しました。

## 監査役に見てほしい点
- 初見ユーザーが最初に押すボタンを1つに絞れているか
- 使徒の説明が短く、スマホで箱庭を大きく隠さないか
- `tick` や schema などの技術用語が初見導線に出ていないか
- localStorageキーが明確で、既存保存を壊していないか
- 許可ファイル以外にscopeが広がっていないか