### PR TITLE
feat: チュートリアル用domain event土台を追加

### DIFF
--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -10,6 +10,22 @@ export type EventTrigger = "routine" | "manual" | "milestone" | "warning" | "agi
 
 export type EventLayer = "flow" | "notable" | "intervention";
 
+export type TutorialEventKind = "firstBless";
+
+export type EventTriggerCandidateKind =
+  | "curiosity"
+  | "encounter"
+  | "discoveryHint"
+  | "relationShift"
+  | "environmentShift";
+
+export interface EventTriggerCandidate {
+  id: EventTriggerCandidateKind;
+  label: string;
+  description: string;
+  recommendedIntervention: InterventionKind;
+}
+
 export type AppPhase = "observing" | "event";
 
 export type TimeControl = "stopped" | "slow" | "normal";
@@ -51,6 +67,7 @@ export interface WorldEvent {
   triggerSummary: string;
   causeSummary: string;
   presetIntervention?: InterventionKind;
+  tutorialKind?: TutorialEventKind;
   trigger: EventTrigger;
   layer: EventLayer;
   targetCharacterId: string;

--- a/src/domain/world.test.ts
+++ b/src/domain/world.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   advanceWorld,
   createInitialWorldState,
+  NON_LIFESPAN_EVENT_TRIGGER_CANDIDATES,
   previewJudgement,
   resolveActiveEvent,
+  triggerTutorialBlessEvent,
 } from "./world";
 
 function getCharacter(state: ReturnType<typeof createInitialWorldState>, id: string) {
@@ -126,5 +128,53 @@ describe("world intervention characterization", () => {
     expect(nextState.timeControl).toBe("stopped");
     expect(nextState.activeEvent).toBeNull();
     expect(nextState.characters.every((character) => !character.alive)).toBe(true);
+  });
+
+  it("creates a deterministic tutorial Bless event that improves the target", () => {
+    const initial = createInitialWorldState();
+    const akiBefore = getCharacter(initial, "aki");
+    const tutorialEvent = triggerTutorialBlessEvent(initial, "aki");
+
+    expect(tutorialEvent.phase).toBe("event");
+    expect(tutorialEvent.activeEvent?.tutorialKind).toBe("firstBless");
+    expect(tutorialEvent.activeEvent?.presetIntervention).toBe("bless");
+    expect(tutorialEvent.activeEvent?.targetCharacterId).toBe("aki");
+
+    const precomputedFumble = previewJudgement(akiBefore, "bless", tutorialEvent.tick, "manual", tutorialEvent.momentum, 1);
+    const resolvedState = resolveActiveEvent(tutorialEvent, "bless", precomputedFumble);
+    const akiAfter = getCharacter(resolvedState, "aki");
+
+    expect(resolvedState.phase).toBe("observing");
+    expect(resolvedState.activeEvent).toBeNull();
+    expect(akiAfter.lifespanRemaining).toBeGreaterThan(akiBefore.lifespanRemaining);
+    expect(akiAfter.blessings).toBeGreaterThanOrEqual(akiBefore.blessings);
+    expect(resolvedState.latestJudgement?.rank).toBe("success");
+  });
+
+  it("keeps Watch and Test safe on the tutorial event", () => {
+    const watchEvent = triggerTutorialBlessEvent(createInitialWorldState(), "aki");
+    const watchResolved = resolveActiveEvent(watchEvent, "watch");
+    const akiAfterWatch = getCharacter(watchResolved, "aki");
+
+    expect(watchResolved.phase).toBe("observing");
+    expect(watchResolved.activeEvent).toBeNull();
+    expect(akiAfterWatch.notable).toContain("Aki に最初の加護を届けます を見届けた");
+
+    const testEvent = triggerTutorialBlessEvent(createInitialWorldState(), "aki");
+    const akiAtTestEvent = getCharacter(testEvent, "aki");
+    const testJudgement = previewJudgement(akiAtTestEvent, "test", testEvent.tick, "manual", testEvent.momentum, 11);
+    const testResolved = resolveActiveEvent(testEvent, "test", testJudgement);
+
+    expect(testResolved.phase).toBe("observing");
+    expect(testResolved.activeEvent).toBeNull();
+    expect(testResolved.latestJudgement?.action).toBe("test");
+  });
+
+  it("documents non-lifespan trigger candidates for future events", () => {
+    expect(NON_LIFESPAN_EVENT_TRIGGER_CANDIDATES.length).toBeGreaterThanOrEqual(2);
+    expect(NON_LIFESPAN_EVENT_TRIGGER_CANDIDATES.map((candidate) => candidate.id)).toEqual(
+      expect.arrayContaining(["curiosity", "encounter", "discoveryHint"]),
+    );
+    expect(NON_LIFESPAN_EVENT_TRIGGER_CANDIDATES.every((candidate) => candidate.recommendedIntervention)).toBe(true);
   });
 });

--- a/src/domain/world.ts
+++ b/src/domain/world.ts
@@ -3,6 +3,7 @@ import type {
   Character,
   DayPhase,
   EventSummary,
+  EventTriggerCandidate,
   InterventionKind,
   JudgementResult,
   LogEntry,
@@ -22,6 +23,33 @@ const EXTINCTION_LOG = "生存者がいなくなりました。箱庭時間を�
 const RECOVERY_LOG = "イベント状態が失われたため、観察状態へ復帰しました。";
 const DAY_PHASES: DayPhase[] = ["morning", "noon", "evening"];
 const SEASONS: Season[] = ["spring", "summer", "autumn", "winter"];
+
+export const NON_LIFESPAN_EVENT_TRIGGER_CANDIDATES: EventTriggerCandidate[] = [
+  {
+    id: "curiosity",
+    label: "好奇心",
+    description: "対象キャラが未知の場所や出来事へ意識を向ける兆し。",
+    recommendedIntervention: "watch",
+  },
+  {
+    id: "encounter",
+    label: "出会い",
+    description: "対象キャラが誰か、または何かと出会い、関係変化の入口に立つ兆し。",
+    recommendedIntervention: "bless",
+  },
+  {
+    id: "discoveryHint",
+    label: "発見の気配",
+    description: "まだ名前のない気配が観測され、新個体発見へつながり得る兆し。",
+    recommendedIntervention: "watch",
+  },
+  {
+    id: "environmentShift",
+    label: "環境変化",
+    description: "天候、季節、土地の変化がキャラの行動を変える兆し。",
+    recommendedIntervention: "test",
+  },
+];
 
 function buildCharacters(): Character[] {
   return [
@@ -247,6 +275,25 @@ function buildInterventionEvent(
     causeSummary: getInterventionCauseSummary(trigger, target),
     presetIntervention,
     trigger,
+    layer: "intervention",
+    targetCharacterId: target.id,
+    targetCharacterName: target.name,
+  };
+}
+
+function buildTutorialBlessEvent(target: Character, tick: number): WorldEvent {
+  return {
+    id: `event-${tick}-${target.id}-tutorial-first-bless`,
+    title: `${target.name} に最初の加護を届けます`,
+    description:
+      `${target.name} が迷いながらも、神の声に気づきかけています。` +
+      "ここでは Bless を選ぶと、初回チュートリアルとして確実に良い変化が起きます。",
+    triggerSummary: "発火条件: 初回チュートリアル導線から、Bless の成功体験を確認するために呼び出されました。",
+    causeSummary:
+      "寿命危機ではなく、神の介入を学ぶための導入イベントです。対象キャラは小さな迷いの中で導きを待っています。",
+    presetIntervention: "bless",
+    tutorialKind: "firstBless",
+    trigger: "manual",
     layer: "intervention",
     targetCharacterId: target.id,
     targetCharacterName: target.name,
@@ -522,6 +569,10 @@ function buildBlessJudgement(
     },
   ];
   return judgement;
+}
+
+function buildTutorialBlessJudgement(character: Character, tick: number): JudgementResult {
+  return buildBlessJudgement(character, "manual", tick, 12);
 }
 
 function buildTestJudgement(
@@ -1066,6 +1117,30 @@ export function triggerManualEvent(state: WorldState): WorldState {
   );
 }
 
+export function triggerTutorialBlessEvent(state: WorldState, targetCharacterId = state.focusCharacterId): WorldState {
+  if (state.phase === "event" && !state.activeEvent) {
+    return recoverStalledEventState(state);
+  }
+
+  if (state.phase === "event") {
+    return state;
+  }
+
+  const target = findAliveTarget(state.characters, targetCharacterId);
+  if (!target) {
+    return pushLog(state, "system", "チュートリアルイベントを起こせる生存者がいません。");
+  }
+
+  return beginEvent(
+    {
+      ...state,
+      focusCharacterId: target.id,
+    },
+    buildTutorialBlessEvent(target, state.tick + 1),
+    `使徒は ${target.name} に初めての加護を届ける場を整えました。まずは Bless を選ぶと、良い変化を確認できます。`,
+  );
+}
+
 export function resolveActiveEvent(
   state: WorldState,
   intervention: InterventionKind,
@@ -1082,9 +1157,11 @@ export function resolveActiveEvent(
 
   const judgementResult =
     intervention === "bless" || intervention === "test"
-      ? precomputedJudgement && precomputedJudgement.action === intervention
-        ? precomputedJudgement
-        : previewJudgement(target, intervention, state.tick, state.activeEvent.trigger, state.momentum)
+      ? state.activeEvent.tutorialKind === "firstBless" && intervention === "bless"
+        ? buildTutorialBlessJudgement(target, state.tick)
+        : precomputedJudgement && precomputedJudgement.action === intervention
+          ? precomputedJudgement
+          : previewJudgement(target, intervention, state.tick, state.activeEvent.trigger, state.momentum)
       : null;
 
   const resolvedTarget =


### PR DESCRIPTION
対象PBI: PBI-TUTORIAL-DOMAIN-EVENT-FOUNDATION-001
対応Issue: #161
Closes #161
branch: feature/pbi-tutorial-domain-event-foundation-001

## 変更ファイル
- `src/domain/types.ts`
- `src/domain/world.ts`
- `src/domain/world.test.ts`

## 今回やったこと
- チュートリアル用の deterministic な `triggerTutorialBlessEvent()` を追加しました。
- 初回Bless成功体験として、チュートリアルBlessでは事前計算済みダイス結果が失敗でも domain 側で成功結果へ固定するようにしました。
- `WorldEvent` に `tutorialKind` を追加し、既存UIの `EventTrigger` union は広げずにチュートリアル識別だけをdomainに持たせました。
- 寿命危機に依存しないイベント候補として、好奇心 / 出会い / 発見の気配 / 環境変化を `NON_LIFESPAN_EVENT_TRIGGER_CANDIDATES` に追加しました。
- Watch / Test でもチュートリアルイベントが壊れないことを domain test で確認しました。
- 既存の tick 12 warning / cooldown / all-dead 停止テストは維持しています。

## 追加したイベントトリガー
- `curiosity`: 好奇心
- `encounter`: 出会い
- `discoveryHint`: 発見の気配
- `environmentShift`: 環境変化

これらは後続実装用の候補であり、既存 `EventTrigger` union は広げていません。既存 `EventModal` の `Record<WorldEvent["trigger"], ...>` を壊さないためです。

## 初回Bless成功イベントの仕様
- `triggerTutorialBlessEvent(state, targetCharacterId?)` で deterministic に作れます。
- `presetIntervention` は `bless`、`tutorialKind` は `firstBless` です。
- Bless 解決時は `precomputedJudgement` より tutorial guarantee を優先します。
- Bless後、対象キャラの残寿命が確実に増えることを test で固定しています。

## 今回やらないこと
- UI実装
- 使徒オーバーレイ実装
- 神様ポイント実装
- 報酬アイテム実装
- 発見UI実装
- localStorage実装
- CSS変更
- `src/app/**` / `src/features/**` / `src/state/**` 変更
- `server/**` 変更
- `sample-games/**` 変更
- package変更
- CI workflow変更

## scope外変更がないこと
- 変更は `src/domain/types.ts`、`src/domain/world.ts`、`src/domain/world.test.ts` のみに閉じています。
- `src/app/**`、`src/features/**`、`src/state/**`、`docs/**`、`public/**`、`sample-games/**`、`server/**`、package、CI workflow は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 許可3ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run test:domain`: 成功（8 tests passed）
- `npm run build`: 成功（既存の chunk size warning あり）

補足: `npm run test:domain` と `npm run build` は sandbox 内で esbuild spawn が `EPERM` になり得るため、通常権限で再実行して成功を確認しました。

## 監査役に見てほしい点
- チュートリアルBlessの成功保証が domain 側に閉じているか
- 既存 `EventTrigger` を広げず、UI型を壊さない判断が妥当か
- 非寿命系イベント候補が後続実装に使える粒度か
- 既存 Watch / Bless / Test 解決処理に退行がないか
- scope外ファイルが混ざっていないか
