### PR TITLE
feat: guide first bless tutorial events

### DIFF
--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -43,6 +43,13 @@ interface DecisionGuideOption {
   nextStep: string;
 }
 
+interface BlessResultCallout {
+  title: string;
+  detail: string;
+}
+
+const FIRST_BLESS_TUTORIAL_MAX_TICK = 12;
+
 function buildRollingState(
   targetCharacter: Character,
   event: WorldEvent,
@@ -159,7 +166,17 @@ function formatModifier(modifier: number) {
   return modifier >= 0 ? `+${modifier}` : `${modifier}`;
 }
 
-function getPauseReason(trigger: WorldEvent["trigger"]) {
+function isTutorialBlessEvent(event: WorldEvent, tick: number) {
+  // The first post-protection warning is the narrowest tutorial-like signal available
+  // without changing the current domain event model.
+  return event.trigger === "warning" && tick <= FIRST_BLESS_TUTORIAL_MAX_TICK;
+}
+
+function getPauseReason(trigger: WorldEvent["trigger"], tutorialBlessEvent: boolean) {
+  if (tutorialBlessEvent) {
+    return "この命が弱り始めたので、最初の Bless でどう助けるかを選ぶために時間が止まっています。";
+  }
+
   switch (trigger) {
     case "warning":
       return "危ない兆しが出たので、見守るか助けるかを決めるために時間が止まっています。";
@@ -172,6 +189,36 @@ function getPauseReason(trigger: WorldEvent["trigger"]) {
     default:
       return "大事な出来事が起きたので、次の行動を選ぶために時間が止まっています。";
   }
+}
+
+function getBlessResultCallout(judgement: JudgementResult | null): BlessResultCallout | null {
+  if (!judgement || judgement.action !== "bless") {
+    return null;
+  }
+
+  const improved = judgement.changes.filter(
+    (change) =>
+      (change.label === "残寿命" || change.label === "加護") &&
+      change.after > change.before,
+  );
+
+  if (improved.length === 0) {
+    return null;
+  }
+
+  const lifespanImproved = improved.some((change) => change.label === "残寿命");
+  const blessingImproved = improved.some((change) => change.label === "加護");
+  const detail = improved.map((change) => `${change.label} ${change.before} → ${change.after}`).join(" / ");
+
+  return {
+    title:
+      lifespanImproved && blessingImproved
+        ? "この Bless で寿命も加護も良い方向へ伸びました"
+        : lifespanImproved
+          ? "この Bless で寿命が良い方向へ伸びました"
+          : "この Bless で加護が良い方向へ伸びました",
+    detail: `変化: ${detail}`,
+  };
 }
 
 export function EventModal({ event, tick, momentum, targetCharacter, onResolve }: EventModalProps) {
@@ -275,12 +322,18 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
   });
   const blessPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "bless", momentum) : 0;
   const testPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "test", momentum) : 0;
-  const pauseReason = getPauseReason(event.trigger);
-  const recommendedIntervention: InterventionKind = event.trigger === "warning" ? "bless" : "watch";
+  const tutorialBlessEvent = isTutorialBlessEvent(event, tick);
+  const pauseReason = getPauseReason(event.trigger, tutorialBlessEvent);
+  const recommendedIntervention: InterventionKind =
+    tutorialBlessEvent || event.trigger === "warning" ? "bless" : "watch";
+  const recommendedBadgeLabel = tutorialBlessEvent ? "初回 Bless" : "おすすめ";
   const recommendedReason =
-    recommendedIntervention === "bless"
+    tutorialBlessEvent
+      ? "今回は Bless を押すと、この命を支える介入が始まります。成功すると残寿命や加護が良い方向へ伸びます。"
+      : recommendedIntervention === "bless"
       ? "命運警告が出ているので、最初は Bless で助けに行くと意図がいちばん分かりやすいです。"
       : "まずは Watch で状況を見守ると、流れをつかみながら次の Test の準備も進められます。";
+  const blessResultCallout = getBlessResultCallout(judgementPreview);
   const decisionGuideOptions: DecisionGuideOption[] = [
     {
       intervention: "watch",
@@ -291,10 +344,16 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     },
     {
       intervention: "bless",
-      summary: "助けて良い結果を狙う",
-      detail: `加護や残寿命を守る方向の介入です。今回の裁定補正は ${formatModifier(blessPreviewModifier)} です。`,
-      context: "危なそうな場面で、まず助けたいときに向いています。",
-      nextStep: "この場で助ける方向へ背中を押す",
+      summary: tutorialBlessEvent ? "今回はこの命を支える体験です" : "助けて良い結果を狙う",
+      detail: tutorialBlessEvent
+        ? `成功すると残寿命や加護が良い方向へ伸びます。今回の裁定補正は ${formatModifier(blessPreviewModifier)} です。`
+        : `加護や残寿命を守る方向の介入です。今回の裁定補正は ${formatModifier(blessPreviewModifier)} です。`,
+      context: tutorialBlessEvent
+        ? "最初の Bless 体験として、助けたいときの流れをつかむのに向いています。"
+        : "危なそうな場面で、まず助けたいときに向いています。",
+      nextStep: tutorialBlessEvent
+        ? "この命を支え、寿命や加護の変化を見る"
+        : "この場で助ける方向へ背中を押す",
     },
     {
       intervention: "test",
@@ -410,7 +469,9 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
             <strong className="event-pause-explainer__title">大事な出来事が起きたので、時間が止まっています</strong>
             <p className="event-pause-explainer__text">{pauseReason}</p>
             <p className="event-pause-explainer__text">
-              ここは正解探しではなく、育てたい方向を選ぶ場面です。選ぶと箱庭の時間が再開します。
+              {tutorialBlessEvent
+                ? "これは正解当てではなく、助けたい方向を選ぶ場面です。今回は Bless で命を支える感覚をつかめば大丈夫です。"
+                : "ここは正解探しではなく、育てたい方向を選ぶ場面です。選ぶと箱庭の時間が再開します。"}
             </p>
             <div className="event-pause-explainer__steps" aria-label="イベントの流れ">
               <span className="event-pause-explainer__step">1. 観察</span>
@@ -458,6 +519,12 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
               <div className={dieClassName}>{rollingValue}</div>
               {rollingState?.revealed && judgementPreview ? (
                 <>
+                  {blessResultCallout ? (
+                    <div className="event-result-callout">
+                      <strong>{blessResultCallout.title}</strong>
+                      <p>{blessResultCallout.detail}</p>
+                    </div>
+                  ) : null}
                   <div className="subpanel judgement-card">
                     <div className="summary-card__header">
                       <h3>裁定結果</h3>
@@ -510,6 +577,13 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
                     迷ったら 1 つずつ役割を読むだけで大丈夫です。最初は「何を増やしたいか」で選ぶと判断しやすくなります。
                   </p>
                 </div>
+                {tutorialBlessEvent ? (
+                  <div className="event-decision-guide__tutorial-callout">
+                    <p className="event-decision-guide__tutorial-eyebrow">apostle guide</p>
+                    <strong>今回は Bless を押すと、この命を支える介入が始まります。</strong>
+                    <p>成功すると残寿命や加護が良い方向へ伸びます。まずは助ける選択の感覚をつかめば十分です。</p>
+                  </div>
+                ) : null}
                 <div className="event-decision-guide__mindset">
                   <strong>どれを選んでも不正解ではありません。</strong>
                   <p>Watch は様子を見る、Bless は助ける、Test は成長を試す選択です。</p>
@@ -526,7 +600,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
                         .join(" ")}
                     >
                       {option.intervention === recommendedIntervention ? (
-                        <span className="event-decision-guide__pill">初回おすすめ</span>
+                        <span className="event-decision-guide__pill">{recommendedBadgeLabel}</span>
                       ) : null}
                       <h4>{labels[option.intervention]}</h4>
                       <p className="event-decision-guide__summary">{option.summary}</p>
@@ -538,7 +612,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
                 </div>
                 <div className="event-decision-guide__recommendation">
                   <strong>
-                    初回おすすめ: {labels[recommendedIntervention]}
+                    {tutorialBlessEvent ? "初回 Bless 推奨" : "おすすめ"}: {labels[recommendedIntervention]}
                   </strong>
                   <p>{recommendedReason}</p>
                 </div>
@@ -547,27 +621,28 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
                 {interventions.map((intervention) => {
                   const option = decisionGuideOptions.find((entry) => entry.intervention === intervention);
                   return (
-                  <button
-                    key={intervention}
-                    type="button"
-                    className={[
-                      "button",
-                      "event-actions__button",
-                      intervention === recommendedIntervention ? "event-actions__button--recommended" : "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ")}
-                    onClick={() => handleResolve(intervention)}
-                  >
-                    {intervention === recommendedIntervention ? (
-                      <span className="event-actions__badge">初回おすすめ</span>
-                    ) : null}
-                    <span className="event-actions__label">{labels[intervention]}</span>
-                    <span className="event-actions__hint">
-                      {option?.summary}
-                    </span>
-                    <span className="event-actions__next">{option?.nextStep}</span>
-                  </button>
+                    <button
+                      key={intervention}
+                      type="button"
+                      className={[
+                        "button",
+                        "event-actions__button",
+                        intervention === recommendedIntervention ? "event-actions__button--recommended" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      onClick={() => handleResolve(intervention)}
+                    >
+                      {intervention === recommendedIntervention ? (
+                        <span className="event-actions__badge">{recommendedBadgeLabel}</span>
+                      ) : null}
+                      <span className="event-actions__label">{labels[intervention]}</span>
+                      {tutorialBlessEvent && intervention === "bless" ? (
+                        <span className="event-actions__tutorial-note">今回はこの命を支える体験です</span>
+                      ) : null}
+                      <span className="event-actions__hint">{option?.summary}</span>
+                      <span className="event-actions__next">{option?.nextStep}</span>
+                    </button>
                   );
                 })}
               </div>

--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -48,8 +48,6 @@ interface BlessResultCallout {
   detail: string;
 }
 
-const FIRST_BLESS_TUTORIAL_MAX_TICK = 12;
-
 function buildRollingState(
   targetCharacter: Character,
   event: WorldEvent,
@@ -166,10 +164,8 @@ function formatModifier(modifier: number) {
   return modifier >= 0 ? `+${modifier}` : `${modifier}`;
 }
 
-function isTutorialBlessEvent(event: WorldEvent, tick: number) {
-  // The first post-protection warning is the narrowest tutorial-like signal available
-  // without changing the current domain event model.
-  return event.trigger === "warning" && tick <= FIRST_BLESS_TUTORIAL_MAX_TICK;
+function isTutorialBlessEvent(event: WorldEvent | null | undefined) {
+  return event?.tutorialKind === "firstBless";
 }
 
 function getPauseReason(trigger: WorldEvent["trigger"], tutorialBlessEvent: boolean) {
@@ -230,6 +226,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     event?.presetIntervention === "bless" || event?.presetIntervention === "test"
       ? event.presetIntervention
       : null;
+  const tutorialBlessEvent = isTutorialBlessEvent(event);
   const activeRollingIntervention = rollingState?.intervention ?? presetPreviewIntervention;
   const illustrationSlot = getModalIllustrationSlot(activeRollingIntervention);
 
@@ -249,7 +246,9 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
       return;
     }
 
-    const finalRoll = Math.floor(Math.random() * 20) + 1;
+    const finalRoll = tutorialBlessEvent && event.presetIntervention === "bless"
+      ? 12
+      : Math.floor(Math.random() * 20) + 1;
     setRollingValue(Math.floor(Math.random() * 20) + 1);
     setRollingState(
       buildRollingState(
@@ -261,7 +260,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
         finalRoll,
       ),
     );
-  }, [event?.id, event?.presetIntervention, momentum, targetCharacter, tick]);
+  }, [event?.id, event?.presetIntervention, momentum, targetCharacter, tick, tutorialBlessEvent]);
 
   useEffect(() => {
     if (!rollingState || rollingState.revealed) {
@@ -322,7 +321,6 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
   });
   const blessPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "bless", momentum) : 0;
   const testPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "test", momentum) : 0;
-  const tutorialBlessEvent = isTutorialBlessEvent(event, tick);
   const pauseReason = getPauseReason(event.trigger, tutorialBlessEvent);
   const recommendedIntervention: InterventionKind =
     tutorialBlessEvent || event.trigger === "warning" ? "bless" : "watch";
@@ -375,7 +373,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
       return;
     }
 
-    const finalRoll = Math.floor(Math.random() * 20) + 1;
+    const finalRoll = tutorialBlessEvent && intervention === "bless" ? 12 : Math.floor(Math.random() * 20) + 1;
     setRollingValue(Math.floor(Math.random() * 20) + 1);
     setRollingState(buildRollingState(targetCharacter, event, tick, momentum, intervention, finalRoll));
   };

--- a/src/features/events/EventModalDecisionGuide.css
+++ b/src/features/events/EventModalDecisionGuide.css
@@ -11,12 +11,14 @@
 .event-cause__eyebrow,
 .event-cause__lead,
 .event-decision-guide__intro,
+.event-decision-guide__tutorial-callout p,
 .event-decision-guide__mindset p,
 .event-decision-guide__summary,
 .event-decision-guide__detail,
 .event-decision-guide__context,
 .event-decision-guide__next-step,
-.event-decision-guide__recommendation p {
+.event-decision-guide__recommendation p,
+.event-result-callout p {
   margin: 0;
 }
 
@@ -118,6 +120,33 @@
   display: block;
   margin-bottom: 0.28rem;
   color: #f4f7fb;
+}
+
+.event-decision-guide__tutorial-callout {
+  border: 1px solid rgba(246, 196, 83, 0.24);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(246, 196, 83, 0.12), rgba(255, 255, 255, 0.02)),
+    rgba(10, 18, 28, 0.84);
+  padding: 0.85rem;
+}
+
+.event-decision-guide__tutorial-callout strong {
+  display: block;
+  margin-bottom: 0.32rem;
+  color: #fff2c8;
+}
+
+.event-decision-guide__tutorial-callout p {
+  color: #d8e4f1;
+  line-height: 1.6;
+}
+
+.event-decision-guide__tutorial-eyebrow {
+  color: #f6d98c;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .event-decision-guide__cards {
@@ -230,10 +259,37 @@
   line-height: 1.45;
 }
 
+.event-actions__tutorial-note {
+  color: #fff1bf;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
 .event-actions__next {
   color: rgba(224, 240, 233, 0.9);
   font-size: 0.78rem;
   line-height: 1.45;
+}
+
+.event-result-callout {
+  border: 1px solid rgba(112, 193, 140, 0.28);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(112, 193, 140, 0.14), rgba(255, 255, 255, 0.02)),
+    rgba(8, 24, 20, 0.88);
+  padding: 0.9rem;
+}
+
+.event-result-callout strong {
+  display: block;
+  margin-bottom: 0.28rem;
+  color: #e4ffe8;
+}
+
+.event-result-callout p {
+  color: #d2f2d9;
+  line-height: 1.55;
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
対象PBI: PBI-TUTORIAL-FIRST-BLESS-EVENT-UX-001
対応Issue: #163
Closes #163
branch: feature/pbi-tutorial-first-bless-event-ux-001

## 変更ファイル
- src/features/events/EventModal.tsx
- src/features/events/EventModalDecisionGuide.css

## チュートリアルBless誘導の内容
- `WorldEvent.tutorialKind === "firstBless"` をチュートリアル Bless 体験の判定に使うようにしました。
- tick 数や `warning` 推測ではなく、domain 側で明示された tutorial event だけを強い Bless 誘導の対象にしています。
- 「これは正解当てではなく、助けたい方向を選ぶ場面」であることを pause explainer と decision guide で明示しました。
- Bless ボタンの近くに「今回はこの命を支える体験です」を追加し、押す前に成功すると残寿命や加護が良い方向へ伸びることを短く示しました。
- チュートリアル Bless の dice preview / resolve は、domain の初回 Bless 成功保証と矛盾しないよう Bless 時に成功ロールとして扱います。
- Bless の裁定結果では、残寿命や加護が実際に増えたときに分かりやすい結果 callout を追加しました。
- スマホでは既存の本文先行レイアウトを維持しつつ、説明と選択導線が画像より先に読める構成を保ちました。

## 通常イベントへの影響有無
- 通常イベントの Watch / Test / Bless 操作は維持しています。
- チュートリアル寄りの強い Bless 誘導は、`tutorialKind: "firstBless"` の event に限定しています。
- 通常の warning や manual event には既存のイベント意思決定導線を残しています。

## 今回やらないこと
- domain event 追加
- Bless成功ロジック変更
- 神様ポイント実装
- 使徒画像アセット追加
- AppShell変更
- FirstActionGuide変更
- package変更

## scope外変更がないこと
- 変更は `src/features/events/EventModal.tsx` と `src/features/events/EventModalDecisionGuide.css` のみです。
- domain / onboarding / sandbox / apostle / app / docs / public / sample-games / package 系 / .github には触れていません。

## 確認結果
- git diff --name-only origin/main...HEAD: src/features/events/EventModal.tsx / src/features/events/EventModalDecisionGuide.css
- git diff --check origin/main...HEAD: 成功
- npm run typecheck: 成功
- npm run test:domain: 成功、8 tests passed
- npm run build: 成功

## 監査役に見てほしい点
- `tutorialKind: "firstBless"` の event だけで Bless が自然に目立つか
- Bless 成功時の結果 callout で、寿命や加護が良い方向へ変わったことが初見にも伝わるか
- 通常イベントでは説明量が増えすぎず、既存の Watch / Test 導線を壊していないか
- iPhone 縦持ちで、画像より先に説明とボタンを読めて押しやすいか
