### PR TITLE
security: record repository secret scan for PBI-SEC-REPO-SECRET-SCAN-001

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# GodSandbox local environment example.
+#
+# The current MVP does not require local secrets to run.
+# Keep real values in untracked `.env` / `.env.*` files only.
+# Do not commit API keys, tokens, passwords, or personal paths.
+
+GOD_SANDBOX_LOCAL_MODE=development

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,15 @@ coverage/
 !.env.example
 god-sandbox-data/
 
+# Local agent/tool scratch files
+.claude/
+*.local.md
+*.log
+*.err.log
+*.out.log
+.local-backup-*/
+node_modules.*-backup/
+
 # 個人環境だけで使う起動補助ファイルは Git 管理しない
 *.local.bat
 *.local.ps1

--- a/docs/security-repo-secret-scan.md
+++ b/docs/security-repo-secret-scan.md
@@ -1,0 +1,155 @@
+# Repository secret scan record
+
+## 目的
+
+この文書は、GodSandbox の Git 管理対象と Git 履歴に secret / API key / token / 個人パス / 本番データが混入していないかを確認した記録です。
+
+検出結果に secret 実値は書きません。問題が見つかった場合も、値そのものではなく「無効化・再発行が必要」とだけ記録します。
+
+## 実施日
+
+2026-05-02
+
+## 対象
+
+- repository: `KitsuneSavaskiy/god-sandbox-mvp`
+- base: `origin/main`
+- branch: `sec/pbi-sec-repo-secret-scan-001`
+- Issue: `#171`
+
+## 実行した確認
+
+### gitleaks
+
+使用した version:
+
+```text
+gitleaks 8.30.1
+```
+
+履歴 scan:
+
+```text
+gitleaks git . --redact=100 --report-format json --exit-code 0
+```
+
+結果:
+
+```text
+219 commits scanned
+findings: 0
+```
+
+現在ファイル scan:
+
+```text
+gitleaks dir . --redact=100 --report-format json --exit-code 0
+```
+
+結果:
+
+```text
+findings: 0
+```
+
+### TruffleHog
+
+使用した version:
+
+```text
+trufflehog 3.95.2
+```
+
+確認内容:
+
+```text
+git scan と filesystem scan を --no-verification で補助実行
+```
+
+結果:
+
+```text
+finding output lines: 0
+```
+
+補足:
+
+この環境では TruffleHog の process exit code が 1 でしたが、標準出力と標準エラーに finding / diagnostic は出ませんでした。そのため、今回の確定判定は gitleaks の履歴 scan と現在ファイル scan を正として扱います。
+
+## 手動確認
+
+### .env の Git 管理状態
+
+確認:
+
+```text
+tracked .env files: 0
+```
+
+`.gitignore` には以下の方針があります。
+
+```text
+.env
+.env.*
+!.env.example
+```
+
+今回、secret 実値を含まない `.env.example` を追加しました。
+
+### 個人パス
+
+検索観点:
+
+```text
+C:\Users\
+OneDrive
+Documents\Codex
+Desktop\Codex
+```
+
+結果:
+
+```text
+実在の個人PCパスとして扱うべき tracked 文字列は見つかりませんでした。
+```
+
+補足:
+
+`.github/CODEOWNERS` の GitHub account 表記と、`docs/startup-troubleshooting.md` の `C:\Users\your-name\...` という説明用 placeholder は検出対象に出ましたが、どちらも個人PCパスや secret 実値ではありません。
+
+### secret 関連語
+
+`secret` / `token` / `API key` / `password` などの語は、運用ルールや安全方針の説明文に含まれています。gitleaks の findings は 0 件であり、今回の scan では secret 実値として扱う検出はありませんでした。
+
+## .gitignore 更新
+
+今回、ローカル補助ファイルを誤って commit しにくくするため、以下を除外対象に追加しました。
+
+```text
+.claude/
+*.local.md
+*.log
+*.err.log
+*.out.log
+.local-backup-*/
+node_modules.*-backup/
+```
+
+## 判断
+
+今回の確認では、Git 管理対象と Git 履歴に secret / API key / token / 本番データの混入は確認されませんでした。
+
+ただし、secret scan は完全保証ではありません。今後、secret / API key / token / 個人パスを見つけた場合は、値を PR や docs に書かず、以下の対応に分けて扱います。
+
+- secret / token / API key: 無効化・再発行が必要
+- 個人パス: 汎用 placeholder へ置換が必要
+- 本番データ: Git 管理対象から除外し、必要なら履歴書き換えを別 PBI として判断
+
+## 今回やらなかったこと
+
+- secret 実値の記録
+- package 変更
+- CI workflow 変更
+- GitHub Actions 追加
+- 履歴書き換え
+- secret の無効化・再発行作業

--- a/docs/security-repo-secret-scan.md
+++ b/docs/security-repo-secret-scan.md
@@ -36,7 +36,7 @@ gitleaks git . --redact=100 --report-format json --exit-code 0
 結果:
 
 ```text
-219 commits scanned
+221 commits scanned
 findings: 0
 ```
 


### PR DESCRIPTION
対象PBI: PBI-SEC-REPO-SECRET-SCAN-001
対応Issue: #171
Closes #171
branch: sec/pbi-sec-repo-secret-scan-001

## 変更ファイル
- `.gitignore`
- `.env.example`
- `docs/security-repo-secret-scan.md`

## 今回やったこと
- `gitleaks` で Git 履歴と現在ファイルを scan し、結果を secret 実値なしで記録しました。
- `TruffleHog` を補助実行し、finding 出力がなかったことと、この環境で exit code 1 だったため確定判定には使わないことを記録しました。
- `.gitignore` の `.env` 除外方針を確認し、ローカル補助ファイルを誤 commit しにくくする除外を追加しました。
- secret 実値なしの `.env.example` を追加しました。

## 今回やらないこと
- secret 実値の記録
- package 変更
- CI workflow 変更
- GitHub Actions 追加
- 履歴書き換え
- secret の無効化・再発行作業

## scope外変更がないこと
- 変更は許可された `.gitignore` / `.env.example` / `docs/security-repo-secret-scan.md` のみに閉じています。
- `src/**` / `server/**` / `sample-games/**` / `samples/**` / `package.json` / `package-lock.json` / `.github/**` / `android/**` / `ios/**` は変更していません。

## 確認結果
- `gitleaks git . --redact=100`: 221 commits scanned、findings 0
- `gitleaks dir . --redact=100`: findings 0
- `TruffleHog`: finding output lines 0。ただし process exit code 1 のため補助確認扱い
- `git diff --name-only origin/main...HEAD`: `.env.example` / `.gitignore` / `docs/security-repo-secret-scan.md`
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功

## 監査役に見てほしい点
- scan 結果に secret 実値を書いていないこと
- TruffleHog の扱いが過剰断定になっていないこと
- `.gitignore` 追加がローカル補助ファイル対策に閉じていること
- scope外ファイルが混ざっていないこと
