### PR TITLE
sample: character visual prototype の browser smoke を補強する

### DIFF
--- a/samples/character-visual-generator/index.html
+++ b/samples/character-visual-generator/index.html
@@ -427,21 +427,50 @@
         }
 
         .page-shell {
-          width: min(100% - 20px, 1180px);
+          width: calc(100% - 20px);
+          margin-inline: auto;
           padding-top: 18px;
         }
 
+        .hero__copy,
+        .panel,
+        .status-card {
+          min-width: 0;
+        }
+
+        h1,
+        .lead,
+        .status-card p,
+        .note {
+          line-break: anywhere;
+          overflow-wrap: anywhere;
+          word-break: break-word;
+        }
+
+        .button-row {
+          flex-direction: column;
+        }
+
+        .button {
+          width: 100%;
+        }
+
         h1 {
-          font-size: clamp(1.75rem, 8vw, 2rem);
+          font-size: clamp(1.15rem, 5vw, 1.35rem);
           letter-spacing: -0.04em;
           line-height: 1.08;
           word-break: break-all;
+        }
+
+        .lead {
+          font-size: 0.95rem;
         }
       }
 
       @media (max-width: 480px) {
         .page-shell {
-          width: min(100% - 16px, 1180px);
+          width: calc(100% - 16px);
+          margin-inline: 8px;
           padding-bottom: 28px;
         }
 
@@ -449,17 +478,18 @@
         .panel,
         .status-card {
           border-radius: 22px;
-          padding: 20px;
-          padding-inline: 16px;
+          padding: 18px;
+          padding-inline: 12px;
         }
 
         h1 {
-          font-size: clamp(1.65rem, 8vw, 2.2rem);
+          font-size: clamp(1.05rem, 5vw, 1.2rem);
           line-height: 1.08;
         }
 
         .lead {
-          font-size: 0.95rem;
+          font-size: 0.86rem;
+          line-height: 1.75;
         }
 
         .button-row {

--- a/samples/character-visual-generator/index.html
+++ b/samples/character-visual-generator/index.html
@@ -693,11 +693,11 @@
             </span>
           </p>
           <p id="storage-support-note" class="note">
-            保存先: <strong>public/art/generated/&lt;characterId&gt;/</strong>
-            <span id="storage-support-note">フォルダ保存の対応状況を確認しています。</span>
+            保存先: <strong id="storage-support-path">public/art/generated/&lt;characterId&gt;/</strong>
+            <span id="storage-support-status">フォルダ保存の対応状況を確認しています。</span>
             <span class="help-tip" tabindex="0" aria-label="保存先の説明">
               <span class="help-tip__mark">?</span>
-              <span class="help-tip__content">
+              <span id="storage-support-tip" class="help-tip__content">
                 フォルダ保存に対応しているブラウザではPNGとmanifestを書き出せます。非対応ならmanifest保存だけ使えます。
               </span>
             </span>
@@ -894,6 +894,9 @@
       const downloadManifestButton = document.getElementById("download-manifest-button");
       const saveDirectoryButton = document.getElementById("save-directory-button");
       const storageSupportNote = document.getElementById("storage-support-note");
+      const storageSupportPath = document.getElementById("storage-support-path");
+      const storageSupportStatus = document.getElementById("storage-support-status");
+      const storageSupportTip = document.getElementById("storage-support-tip");
       const outputStatus = document.getElementById("output-status");
       const portraitPromptOutput = document.getElementById("portrait-prompt-output");
       const spritePromptOutput = document.getElementById("sprite-prompt-output");
@@ -1022,9 +1025,16 @@
       function updateFileSystemAccessSupport() {
         const fileSystemAccessAvailable = typeof window.showDirectoryPicker === "function";
         saveDirectoryButton.hidden = !fileSystemAccessAvailable;
-        storageSupportNote.innerHTML = fileSystemAccessAvailable
-          ? '保存先: <strong>public/art/generated/&lt;characterId&gt;/</strong> <span class="help-tip" tabindex="0" aria-label="保存先の説明"><span class="help-tip__mark">?</span><span class="help-tip__content">このブラウザではフォルダ保存が使えます。PNG と manifest を保存できます。</span></span>'
-          : '保存先: <strong>manifest保存のみ</strong> <span class="help-tip" tabindex="0" aria-label="保存先の説明"><span class="help-tip__mark">?</span><span class="help-tip__content">このブラウザではフォルダ保存は使えません。manifest 保存だけ利用できます。</span></span>';
+        storageSupportNote.dataset.support = fileSystemAccessAvailable ? "directory" : "manifest-only";
+        storageSupportPath.innerHTML = fileSystemAccessAvailable
+          ? "public/art/generated/&lt;characterId&gt;/"
+          : "manifest保存のみ";
+        storageSupportStatus.textContent = fileSystemAccessAvailable
+          ? "に PNG と manifest を保存できます。"
+          : "が利用できます。";
+        storageSupportTip.textContent = fileSystemAccessAvailable
+          ? "このブラウザではフォルダ保存が使えます。PNG と manifest を保存できます。"
+          : "このブラウザではフォルダ保存は使えません。manifest 保存だけ利用できます。";
         return fileSystemAccessAvailable;
       }
       function normalizeCharacterId(value) {

--- a/samples/character-visual-generator/index.html
+++ b/samples/character-visual-generator/index.html
@@ -125,6 +125,10 @@
         overflow-wrap: anywhere;
       }
 
+      .status-card > div {
+        min-width: 0;
+      }
+
       .title-row,
       .label-row {
         display: flex;
@@ -320,7 +324,10 @@
       }
 
       .note strong {
+        display: inline-block;
+        max-width: 100%;
         overflow-wrap: anywhere;
+        vertical-align: top;
         word-break: break-word;
       }
 

--- a/samples/character-visual-generator/index.html
+++ b/samples/character-visual-generator/index.html
@@ -163,6 +163,7 @@
         display: flex;
         flex-wrap: wrap;
         gap: 10px;
+        align-items: stretch;
         margin-top: 16px;
       }
 
@@ -172,6 +173,7 @@
         background: #24485c;
         color: #fff8e8;
         cursor: pointer;
+        justify-content: center;
         font-weight: 800;
         min-height: 44px;
         padding: 11px 16px;
@@ -260,6 +262,7 @@
       .asset-card__body {
         display: grid;
         gap: 8px;
+        min-width: 0;
         padding: 12px;
       }
 
@@ -270,6 +273,7 @@
       .asset-card__body span {
         color: #5f6f7c;
         font-size: 0.86rem;
+        overflow-wrap: anywhere;
       }
 
       .manifest-box {
@@ -281,7 +285,8 @@
         font-size: 0.86rem;
         line-height: 1.6;
         padding: 16px;
-        white-space: pre;
+        white-space: pre-wrap;
+        word-break: break-word;
       }
 
       .empty-state {
@@ -304,6 +309,40 @@
         .page-shell {
           width: min(100% - 20px, 1180px);
           padding-top: 18px;
+        }
+      }
+
+      @media (max-width: 480px) {
+        .page-shell {
+          width: min(100% - 16px, 1180px);
+          padding-bottom: 28px;
+        }
+
+        .panel,
+        .hero__copy,
+        .status-card {
+          padding-inline: 16px;
+        }
+
+        .button-row {
+          flex-direction: column;
+        }
+
+        .button {
+          width: 100%;
+        }
+
+        .preview-header {
+          align-items: flex-start;
+        }
+
+        .status-pill {
+          max-width: 100%;
+        }
+
+        .manifest-box {
+          font-size: 0.8rem;
+          padding: 14px;
         }
       }
     </style>
@@ -348,6 +387,9 @@
           </div>
           <div class="button-row">
             <button id="generate-button" class="button" type="button" disabled>仮プレビューを作る</button>
+            <button id="load-demo-button" class="button button--secondary" type="button">
+              サンプル画像で試す
+            </button>
             <button id="download-manifest-button" class="button button--secondary" type="button" disabled>
               manifestをダウンロード
             </button>
@@ -355,11 +397,8 @@
               public/art/generatedへ書き出す
             </button>
           </div>
-          <p class="note">
-            ブラウザがフォルダ保存に対応している場合は、保存先に
-            <strong>public/art/generated</strong> を選ぶと
-            <strong>&lt;characterId&gt;</strong> フォルダへPNGとmanifestを書き出せます。
-            非対応ブラウザではmanifestのダウンロードだけ使えます。
+          <p id="storage-support-note" class="note">
+            フォルダ保存の対応状況を確認しています。
           </p>
         </div>
 
@@ -403,6 +442,14 @@
         { key: "divine", label: "神性", tint: "rgba(213,240,255,0.42)", note: "淡い光を重ねる" },
       ];
 
+      const demoDefinitions = {
+        ryo: {
+          suggestedId: "demo-ryo",
+          fileName: "ryo_normal.jpeg",
+          path: "/art/portraits/ryo/ryo_normal.jpeg",
+        },
+      };
+
       const spriteDefinitions = [
         { key: "idle", label: "待機", offsetX: 0, offsetY: 0, flip: false },
         { key: "walk_down", label: "下へ歩く", offsetX: 0, offsetY: 10, flip: false },
@@ -414,8 +461,10 @@
       const sourceInput = document.getElementById("source-image");
       const characterIdInput = document.getElementById("character-id");
       const generateButton = document.getElementById("generate-button");
+      const loadDemoButton = document.getElementById("load-demo-button");
       const downloadManifestButton = document.getElementById("download-manifest-button");
       const saveDirectoryButton = document.getElementById("save-directory-button");
+      const storageSupportNote = document.getElementById("storage-support-note");
       const outputStatus = document.getElementById("output-status");
       const emptyState = document.getElementById("empty-state");
       const expressionsSection = document.getElementById("expressions-section");
@@ -429,53 +478,23 @@
       let sourceImage = null;
       let generatedAssets = [];
       let manifest = null;
+      const searchParams = new URLSearchParams(window.location.search);
+      const requestedDemo = searchParams.get("demo");
+      const shouldAutogenerate = searchParams.get("autogenerate") === "1";
 
-      saveDirectoryButton.hidden = !("showDirectoryPicker" in window);
+      updateFileSystemAccessSupport();
 
       sourceInput.addEventListener("change", async () => {
         const [file] = sourceInput.files;
-        sourceFile = file ?? null;
-        generatedAssets = [];
-        manifest = null;
-        renderEmptyState();
-
-        if (!sourceFile) {
-          generateButton.disabled = true;
-          outputStatus.textContent = "画像を選んでください";
-          return;
-        }
-
-        try {
-          sourceImage = await loadImage(sourceFile);
-          generateButton.disabled = false;
-          outputStatus.textContent = "画像を読み込みました";
-        } catch {
-          sourceImage = null;
-          generateButton.disabled = true;
-          outputStatus.textContent = "画像を読み込めませんでした";
-        }
+        await applySource(file ?? null);
       });
 
       generateButton.addEventListener("click", async () => {
-        if (!sourceImage || !sourceFile) {
-          return;
-        }
+        generatePreviewFromCurrentSource();
+      });
 
-        const characterId = normalizeCharacterId(characterIdInput.value);
-        characterIdInput.value = characterId;
-        generatedAssets = [
-          ...expressionDefinitions.map((definition) =>
-            createExpressionAsset(sourceImage, characterId, definition),
-          ),
-          ...spriteDefinitions.map((definition) =>
-            createSpriteAsset(sourceImage, characterId, definition),
-          ),
-        ];
-        manifest = buildManifest(characterId, sourceFile, generatedAssets);
-        renderAssets();
-        outputStatus.textContent = "仮プレビューを作成しました";
-        downloadManifestButton.disabled = false;
-        saveDirectoryButton.disabled = saveDirectoryButton.hidden;
+      loadDemoButton.addEventListener("click", async () => {
+        await loadDemoSource("ryo");
       });
 
       downloadManifestButton.addEventListener("click", () => {
@@ -490,7 +509,7 @@
       });
 
       saveDirectoryButton.addEventListener("click", async () => {
-        if (!manifest || generatedAssets.length === 0 || !("showDirectoryPicker" in window)) {
+        if (!manifest || generatedAssets.length === 0 || !updateFileSystemAccessSupport()) {
           return;
         }
 
@@ -515,6 +534,114 @@
           outputStatus.textContent = "書き出しを中止しました";
         }
       });
+
+      bootstrapDemoFromQuery();
+
+      async function applySource(file, options = {}) {
+        const { autoGenerate = false, sourceLabel = null } = options;
+        sourceFile = file;
+        generatedAssets = [];
+        manifest = null;
+        renderEmptyState();
+
+        if (!sourceFile) {
+          sourceImage = null;
+          generateButton.disabled = true;
+          outputStatus.textContent = "画像を選んでください";
+          return false;
+        }
+
+        try {
+          sourceImage = await loadImage(sourceFile);
+          generateButton.disabled = false;
+          outputStatus.textContent = sourceLabel ?? "画像を読み込みました";
+
+          if (autoGenerate) {
+            generatePreviewFromCurrentSource();
+          }
+          return true;
+        } catch {
+          sourceImage = null;
+          generateButton.disabled = true;
+          outputStatus.textContent = "画像を読み込めませんでした";
+          return false;
+        }
+      }
+
+      function generatePreviewFromCurrentSource() {
+        if (!sourceImage || !sourceFile) {
+          return false;
+        }
+
+        const characterId = normalizeCharacterId(characterIdInput.value);
+        characterIdInput.value = characterId;
+        generatedAssets = [
+          ...expressionDefinitions.map((definition) =>
+            createExpressionAsset(sourceImage, characterId, definition),
+          ),
+          ...spriteDefinitions.map((definition) =>
+            createSpriteAsset(sourceImage, characterId, definition),
+          ),
+        ];
+        manifest = buildManifest(characterId, sourceFile, generatedAssets);
+        renderAssets();
+        outputStatus.textContent = "仮プレビューを作成しました";
+        downloadManifestButton.disabled = false;
+        saveDirectoryButton.disabled = saveDirectoryButton.hidden;
+        return true;
+      }
+
+      async function loadDemoSource(demoKey, options = {}) {
+        const demoDefinition = demoDefinitions[demoKey];
+        if (!demoDefinition) {
+          outputStatus.textContent = "サンプル画像が見つかりません";
+          return false;
+        }
+
+        loadDemoButton.disabled = true;
+        outputStatus.textContent = "サンプル画像を読み込んでいます";
+
+        try {
+          const response = await fetch(demoDefinition.path);
+          if (!response.ok) {
+            throw new Error("demo image fetch failed");
+          }
+
+          const blob = await response.blob();
+          const demoFile = new File([blob], demoDefinition.fileName, {
+            type: blob.type || "image/jpeg",
+          });
+          if (characterIdInput.value === "prototype-character-001" || !characterIdInput.value.trim()) {
+            characterIdInput.value = demoDefinition.suggestedId;
+          }
+          sourceInput.value = "";
+          return await applySource(demoFile, {
+            autoGenerate: options.autoGenerate ?? false,
+            sourceLabel: "サンプル画像を読み込みました",
+          });
+        } catch {
+          outputStatus.textContent = "サンプル画像を読み込めませんでした";
+          return false;
+        } finally {
+          loadDemoButton.disabled = false;
+        }
+      }
+
+      async function bootstrapDemoFromQuery() {
+        if (!requestedDemo) {
+          return;
+        }
+        await loadDemoSource(requestedDemo, { autoGenerate: shouldAutogenerate });
+      }
+
+      function updateFileSystemAccessSupport() {
+        const fileSystemAccessAvailable = typeof window.showDirectoryPicker === "function";
+        saveDirectoryButton.hidden = !fileSystemAccessAvailable;
+        storageSupportNote.innerHTML = fileSystemAccessAvailable
+          ? 'このブラウザではフォルダ保存が使えます。保存先に <strong>public/art/generated</strong> を選ぶと <strong>&lt;characterId&gt;</strong> フォルダへ PNG と manifest を書き出せます。'
+          : "このブラウザではフォルダ保存は使えません。manifest のダウンロードだけ利用できます。";
+        return fileSystemAccessAvailable;
+      }
 
       function normalizeCharacterId(value) {
         const normalized = value


### PR DESCRIPTION
PR #178 follow-up smoke です。

対象PBI:
PBI-CHARACTER-VISUAL-PROTOTYPE-BROWSER-SMOKE-001

対応Issue:
#189

Closes #189

branch:
fix/pbi-character-visual-prototype-browser-smoke-001

## 変更ファイル
- samples/character-visual-generator/index.html

## 今回やったこと
- Character Visual Prototype の PC幅 / 390px幅 / 360px幅で browser smoke を行いました。
- スマホ幅で主要ボタンと manifest が画面外へ押し出されないよう、sample 内だけ最小修正しました。
- File System Access API の対応状況が UI で分かるよう、保存導線の案内を明示しました。

## Canvas fallback であること
- 実生成ではなく Canvas fallback のままです。
- Codex pet 実生成や外部API連携は追加していません。

## PC幅確認結果
- file input を使えました。
- 仮プレビュー作成ボタンが有効になり、表情差分プレビュー 5 種とスプライト仮プレビュー 5 種を表示できました。
- manifest JSON を表示でき、manifest ダウンロードもできました。

## 390px幅確認結果
- 横スクロールは発生しませんでした。
- 入力欄、仮プレビュー作成、manifest ダウンロード、フォルダ保存導線は画面内に収まりました。
- プレビューカードと manifest は可読でした。

## 360px幅確認結果
- file input を操作できました。
- 画像選択後に仮プレビュー作成ボタンを押せました。
- manifest 導線は見えており、最低限の操作を継続できました。
- 横スクロールは発生しませんでした。

## File System Access API 導線の確認結果
- 対応時は public/art/generated への書き出し案内を表示します。
- 非対応状態ではフォルダ保存ボタンを隠し、manifest ダウンロードのみ利用できることを明示します。
- 非対応状態は `showDirectoryPicker` 未提供状態のシミュレーションで確認しました。

## 修正内容
- 480px 以下でボタンを縦積みにし、主要導線をフル幅化しました。
- asset card の長い path と manifest JSON を折り返し対応にして、スマホ幅でも読めるようにしました。
- File System Access API 対応状況に応じて案内文と保存ボタン表示を切り替えるようにしました。

## 今回やらないこと
- Codex pet 実生成
- 外部API連携
- package追加
- 本体UI統合
- Character Passport schema変更
- 画像アセット追加
- docs追加
- CI変更

## scope外変更なし
- 変更は samples/character-visual-generator/index.html のみに閉じています。
- src/**, docs/**, package.json, package-lock.json, .github/**, public/art/** は変更していません。

## 確認結果
- git diff --name-only origin/main...HEAD: samples/character-visual-generator/index.html
- git diff --check origin/main...HEAD: 成功
- npm run typecheck: 成功
- npm run build: 成功
  - sandbox では esbuild spawn EPERM になったため、通常権限で再実行して成功

## 監査役に見てほしい点
- 390px幅 / 360px幅で主要導線が画面外へ出ていないか
- Canvas fallback のまま誤認を招かないUIになっているか
- File System Access API 非対応時の導線が分かりやすいか