### PR TITLE
fix: improve art visibility and mobile fallbacks

### DIFF
--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -66,6 +66,7 @@ export function ApostlePanel({
   onTriggerManualEvent,
 }: ApostlePanelProps) {
   const [notesExpanded, setNotesExpanded] = useState(false);
+  const [portraitLoadFailed, setPortraitLoadFailed] = useState(false);
   const [tutorialBlessJudgement, setTutorialBlessJudgement] = useState<JudgementResult | null>(null);
 
   useEffect(() => {
@@ -86,6 +87,10 @@ export function ApostlePanel({
     : null;
   const recentNotables = focusedCharacter ? [...focusedCharacter.notable].slice(-3).reverse() : [];
   const portraitSrc = getPanelPortraitSrc(paused, latestJudgement);
+
+  useEffect(() => {
+    setPortraitLoadFailed(false);
+  }, [portraitSrc]);
 
   return (
     <section className="panel">
@@ -180,19 +185,32 @@ export function ApostlePanel({
           <h3>アート受け皿</h3>
           <span className="placeholder-chip">接続済み</span>
         </div>
-        <div className="art-slot art-slot--portrait art-slot--with-image">
-          <img
-            className="art-slot__image"
-            src={portraitSrc}
-            alt="Ryo portrait base"
-          />
-          <div className="art-slot__meta">
-            <span className="art-slot__eyebrow">portrait slot / ryo asset preview</span>
-            <strong>{portraitGuide.subjectLabel}</strong>
-            <span>{portraitGuide.toneLabel}</span>
-            <span>{portraitGuide.expressionLine}</span>
-            <p className="summary-note">{portraitGuide.note}</p>
-          </div>
+        <div className={["art-slot", "art-slot--portrait", portraitLoadFailed ? "" : "art-slot--with-image"].filter(Boolean).join(" ")}>
+          {portraitLoadFailed ? (
+            <>
+              <span className="art-slot__eyebrow">portrait slot / fallback</span>
+              <strong>{portraitGuide.subjectLabel}</strong>
+              <span>{portraitGuide.toneLabel}</span>
+              <span>画像を読み込めなかったため、説明表示に切り替えています。</span>
+              <p className="summary-note">{portraitGuide.note}</p>
+            </>
+          ) : (
+            <>
+              <img
+                className="art-slot__image"
+                src={portraitSrc}
+                alt="Ryo portrait base"
+                onError={() => setPortraitLoadFailed(true)}
+              />
+              <div className="art-slot__meta">
+                <span className="art-slot__eyebrow">portrait slot / ryo asset preview</span>
+                <strong>{portraitGuide.subjectLabel}</strong>
+                <span>{portraitGuide.toneLabel}</span>
+                <span>{portraitGuide.expressionLine}</span>
+                <p className="summary-note">{portraitGuide.note}</p>
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/src/features/events/EventModal.tsx
+++ b/src/features/events/EventModal.tsx
@@ -221,6 +221,7 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
   const [rollingState, setRollingState] = useState<RollingState | null>(null);
   const [rollingValue, setRollingValue] = useState(1);
   const [illustrationLoadFailed, setIllustrationLoadFailed] = useState(false);
+  const [portraitLoadFailed, setPortraitLoadFailed] = useState(false);
   const confirmLockRef = useRef(false);
   const presetPreviewIntervention =
     event?.presetIntervention === "bless" || event?.presetIntervention === "test"
@@ -229,11 +230,21 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
   const tutorialBlessEvent = isTutorialBlessEvent(event);
   const activeRollingIntervention = rollingState?.intervention ?? presetPreviewIntervention;
   const illustrationSlot = getModalIllustrationSlot(activeRollingIntervention);
+  const portraitSrc = event
+    ? getModalPortraitSrc({
+        event,
+        targetCharacter,
+        activeIntervention: activeRollingIntervention,
+        judgementPreview: rollingState?.judgement ?? null,
+        revealed: rollingState?.revealed ?? false,
+      })
+    : RYO_PORTRAITS.normal;
 
   useEffect(() => {
     setRollingState(null);
     setRollingValue(1);
     setIllustrationLoadFailed(false);
+    setPortraitLoadFailed(false);
     confirmLockRef.current = false;
   }, [event?.id]);
 
@@ -304,6 +315,10 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     setIllustrationLoadFailed(false);
   }, [illustrationSlot.src]);
 
+  useEffect(() => {
+    setPortraitLoadFailed(false);
+  }, [portraitSrc]);
+
   if (!event) {
     return null;
   }
@@ -312,13 +327,6 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
   const isRolling =
     !!presetPreviewIntervention || rollingState?.intervention === "bless" || rollingState?.intervention === "test";
   const judgementPreview = rollingState?.judgement ?? null;
-  const portraitSrc = getModalPortraitSrc({
-    event,
-    targetCharacter,
-    activeIntervention: activeRollingIntervention,
-    judgementPreview,
-    revealed: rollingState?.revealed ?? false,
-  });
   const blessPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "bless", momentum) : 0;
   const testPreviewModifier = targetCharacter ? getInterventionModifier(targetCharacter, "test", momentum) : 0;
   const pauseReason = getPauseReason(event.trigger, tutorialBlessEvent);
@@ -410,17 +418,29 @@ export function EventModal({ event, tick, momentum, targetCharacter, onResolve }
     <div className="modal-backdrop" role="presentation">
       <section className="modal-card event-modal" role="dialog" aria-modal="true" aria-labelledby="event-title">
         <div className="modal-card__media">
-          <div className="art-slot art-slot--portrait art-slot--with-image">
-            <img
-              className="art-slot__image"
-              src={portraitSrc}
-              alt="Ryo portrait expression"
-            />
-            <div className="art-slot__meta">
-              <span className="art-slot__eyebrow">portrait slot / ryo asset preview</span>
-              <strong>基準キャラ: Ryo（portrait 接続済み）</strong>
-              <span>{eventArtGuide.portraitLine}</span>
-            </div>
+          <div className={["art-slot", "art-slot--portrait", portraitLoadFailed ? "" : "art-slot--with-image"].filter(Boolean).join(" ")}>
+            {portraitLoadFailed ? (
+              <>
+                <span className="art-slot__eyebrow">portrait slot / fallback</span>
+                <strong>基準キャラ: Ryo（portrait 接続済み）</strong>
+                <span>{eventArtGuide.portraitLine}</span>
+                <span>portrait 画像を読み込めなかったため、説明表示に切り替えています。</span>
+              </>
+            ) : (
+              <>
+                <img
+                  className="art-slot__image"
+                  src={portraitSrc}
+                  alt="Ryo portrait expression"
+                  onError={() => setPortraitLoadFailed(true)}
+                />
+                <div className="art-slot__meta">
+                  <span className="art-slot__eyebrow">portrait slot / ryo asset preview</span>
+                  <strong>基準キャラ: Ryo（portrait 接続済み）</strong>
+                  <span>{eventArtGuide.portraitLine}</span>
+                </div>
+              </>
+            )}
           </div>
           <div
             className={[

--- a/src/features/onboarding/LoginOpeningMovie.tsx
+++ b/src/features/onboarding/LoginOpeningMovie.tsx
@@ -65,7 +65,7 @@ export function LoginOpeningMovie({ userName, onComplete }: LoginOpeningMoviePro
               autoPlay
               muted
               playsInline
-              preload="auto"
+              preload="metadata"
               onEnded={onComplete}
               onError={() => setLoadFailed(true)}
             />

--- a/src/features/sandbox/WorldViewport.tsx
+++ b/src/features/sandbox/WorldViewport.tsx
@@ -131,6 +131,7 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
           : "夜";
   const seasonLabel =
     season === "spring" ? "春" : season === "summer" ? "夏" : season === "autumn" ? "秋" : "冬";
+  const showViewportGuide = !paused;
 
   useEffect(() => {
     setBackgroundLoadFailed(false);
@@ -420,51 +421,55 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
           <span>金</span>
           <span>水</span>
         </div>
-        <details className="world-viewport-guide" aria-label="箱庭ガイド">
-          <summary className="world-viewport-guide__bar">
-            <span className="world-viewport-guide__eyebrow">Sandbox Guide</span>
-            <span className="world-viewport-guide__chip">ここが箱庭</span>
-            <span className="world-viewport-guide__chip">ドラッグで見回す</span>
-            <span className="world-viewport-guide__chip">光る人物を追う</span>
-            <span className="world-viewport-guide__expand">詳しく見る</span>
-          </summary>
-          <div className="world-viewport-guide__panel">
-            <h2 className="world-viewport-guide__title">箱庭の見方</h2>
-            <p className="world-viewport-guide__text">{guideSummary}</p>
-            <div className="world-viewport-guide__mini-stats" aria-label="箱庭の現在地">
-              <span>全員 {totalCharacters}</span>
-              <span>生存 {livingCount}</span>
-              <span>変化 {noteworthyCount}</span>
+        {showViewportGuide ? (
+          <>
+            <details className="world-viewport-guide" aria-label="箱庭ガイド">
+              <summary className="world-viewport-guide__bar">
+                <span className="world-viewport-guide__eyebrow">Sandbox Guide</span>
+                <span className="world-viewport-guide__chip">ここが箱庭</span>
+                <span className="world-viewport-guide__chip">ドラッグで見回す</span>
+                <span className="world-viewport-guide__chip">光る人物を追う</span>
+                <span className="world-viewport-guide__expand">詳しく見る</span>
+              </summary>
+              <div className="world-viewport-guide__panel">
+                <h2 className="world-viewport-guide__title">箱庭の見方</h2>
+                <p className="world-viewport-guide__text">{guideSummary}</p>
+                <div className="world-viewport-guide__mini-stats" aria-label="箱庭の現在地">
+                  <span>全員 {totalCharacters}</span>
+                  <span>生存 {livingCount}</span>
+                  <span>変化 {noteworthyCount}</span>
+                </div>
+                <p className="world-viewport-guide__focus">いま見る: {focusLabel}</p>
+                <div className="world-viewport-guide__cta">{nextAction}</div>
+                <p className="world-viewport-guide__state">今の気配: {omen}</p>
+              </div>
+            </details>
+            <div className="viewport-overlay__controls">
+              <div className="viewport-overlay__chip viewport-overlay__chip--controls">
+                視点 {cameraMode === "follow" ? `自動追従 / ${focusTarget?.name ?? "対象なし"}` : "自由視点"}
+              </div>
+              <div className="viewport-controls">
+                <button
+                  className="button button--ghost viewport-controls__button"
+                  type="button"
+                  onClick={() => setCameraZoom((current) => clamp(current - 0.15, MIN_ZOOM, MAX_ZOOM))}
+                >
+                  -
+                </button>
+                <button
+                  className="button button--ghost viewport-controls__button"
+                  type="button"
+                  onClick={() => setCameraZoom((current) => clamp(current + 0.15, MIN_ZOOM, MAX_ZOOM))}
+                >
+                  +
+                </button>
+                <button className="button button--ghost viewport-controls__button" type="button" onClick={handleResetFocus}>
+                  フォーカスに戻る
+                </button>
+              </div>
             </div>
-            <p className="world-viewport-guide__focus">いま見る: {focusLabel}</p>
-            <div className="world-viewport-guide__cta">{nextAction}</div>
-            <p className="world-viewport-guide__state">今の気配: {omen}</p>
-          </div>
-        </details>
-        <div className="viewport-overlay__controls">
-          <div className="viewport-overlay__chip viewport-overlay__chip--controls">
-            視点 {cameraMode === "follow" ? `自動追従 / ${focusTarget?.name ?? "対象なし"}` : "自由視点"}
-          </div>
-          <div className="viewport-controls">
-            <button
-              className="button button--ghost viewport-controls__button"
-              type="button"
-              onClick={() => setCameraZoom((current) => clamp(current - 0.15, MIN_ZOOM, MAX_ZOOM))}
-            >
-              -
-            </button>
-            <button
-              className="button button--ghost viewport-controls__button"
-              type="button"
-              onClick={() => setCameraZoom((current) => clamp(current + 0.15, MIN_ZOOM, MAX_ZOOM))}
-            >
-              +
-            </button>
-            <button className="button button--ghost viewport-controls__button" type="button" onClick={handleResetFocus}>
-              フォーカスに戻る
-            </button>
-          </div>
-        </div>
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -569,16 +569,20 @@ button {
 .modal-backdrop {
   position: fixed;
   inset: 0;
+  z-index: 40;
   display: grid;
   place-items: center;
   overflow-y: auto;
   background: rgba(2, 7, 12, 0.78);
   padding: 1rem;
   -webkit-overflow-scrolling: touch;
+  isolation: isolate;
 }
 
 .modal-card {
   display: grid;
+  position: relative;
+  z-index: 1;
   width: min(980px, 100%);
   max-height: calc(100vh - 2rem);
   overflow-y: auto;


### PR DESCRIPTION
対象PBI: PBI-ART-ASSET-VISIBILITY-MOBILE-FALLBACK-001
対応Issue: #185
Closes #185
branch: feature/pbi-art-asset-visibility-mobile-fallback-001

## 変更ファイル
- `src/features/apostle/ApostlePanel.tsx`
- `src/features/events/EventModal.tsx`
- `src/features/onboarding/LoginOpeningMovie.tsx`
- `src/features/sandbox/WorldViewport.tsx`
- `src/index.css`

## 今回やったこと
- イベント停止中に箱庭ガイドと視点操作を隠すようにしました。
- `EventModal` の backdrop / card の stacking を明示し、3D箱庭がモーダル本文の前に出ないようにしました。
- `ApostlePanel` / `EventModal` の portrait 読み込み失敗時に、壊れた画像ではなく説明fallbackへ切り替えるようにしました。
- `LoginOpeningMovie` の動画 preload を `metadata` に変更し、初回読み込みを軽くしました。

## 今回やらないこと
- package変更
- CI変更
- docs変更
- `public/art/**` 変更
- Passport schema変更
- 新規アセット追加

## scope外変更がないこと
- 変更は上記5ファイルのみに閉じています。
- `package.json` / `package-lock.json` / `.github/**` / `docs/**` / `public/art/**` は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 上記5ファイルのみ
- `git diff --check`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功

## 視覚確認
- 390px幅で初回画面と手動イベントモーダルを確認しました。
- イベント停止中に箱庭ガイド/視点操作が消え、モーダル本文が箱庭レイヤーに被らないことを確認しました。

## 監査役に見てほしい点
- 5ファイルのscopeに閉じているか
- `EventModal` がスマホ幅で箱庭レイヤーに邪魔されないか
- portrait load fallback が実生成済み画像と誤認されないか
- 動画 preload 変更が初回導線を壊していないか
