### PR TITLE
docs: README冒頭に初見向けローカル起動手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,54 @@
 
 Codex と一緒に開発している、神視点箱庭プロトタイプの公開 MVP リポジトリです。
 
+## はじめて遊ぶ方へ
+
+GodSandbox は、新米神様として小さな箱庭のキャラクターを見守り、必要な時に助ける育成サンドボックスです。
+
+まずは Windows PC で、次の順番に進めてください。
+
+### 1. ダウンロードする
+
+1. GitHub ページ右上の `Code` を押します。
+2. `Download ZIP` を押します。
+3. ZIP ファイルをデスクトップなど分かりやすい場所へ展開します。
+
+### 2. Node.js を用意する
+
+GodSandbox を起動するには Node.js が必要です。
+
+入っていない場合は、[Node.js 公式サイト](https://nodejs.org/) からインストールしてください。
+
+### 3. 起動する
+
+Windows では、展開したフォルダの中にある `start.bat` をダブルクリックします。
+
+起動したら、ブラウザで次を開きます。
+
+`http://localhost:5173`
+
+PowerShell を使う場合は、補足として次でも起動できます。
+
+```powershell
+.\start.ps1
+```
+
+### 4. 終了する
+
+起動中の黒い画面または PowerShell で `Ctrl+C` を押します。
+
+### スマホから見る場合
+
+PC と iPhone / Android を同じ Wi-Fi につなぎます。
+
+起動時に表示される `Network:` の URL を、スマホの Safari または Chrome で開きます。
+
+### 困ったとき
+
+詳しい起動トラブルは [docs/startup-troubleshooting.md](docs/startup-troubleshooting.md) を見てください。
+
+---
+
 自動作業 PR の smoke test 記録: 4。
 
 ---


### PR DESCRIPTION
## 対象PBI
PBI-README-FIRST-TIME-LOCAL-START-GUIDE-001

## 対応Issue
Closes #199

## branch
`docs/pbi-readme-first-time-local-start-guide-001`

## 変更ファイル
- `README.md`

## 今回やったこと
- README冒頭に「はじめて遊ぶ方へ」セクションを追加しました。
- GodSandboxを「新米神様として箱庭のキャラを見守り、必要な時に助ける育成サンドボックス」と短く説明しました。
- GitHubの `Code` → `Download ZIP` → デスクトップ等へ展開、という初見向け手順を追加しました。
- Node.js が必要であることを短く説明しました。
- Windowsでは `start.bat` ダブルクリックを最優先の起動導線として書きました。
- PowerShellの `./start.ps1` は補足に留めました。
- 起動後に `http://localhost:5173` を開くこと、終了時は `Ctrl+C` を押すことを書きました。
- iPhone / Android はPCと同じWi-Fiにつなぎ、起動時の `Network:` URLをSafari/Chromeで開く案内を追加しました。
- 詳細なトラブルシューティングは `docs/startup-troubleshooting.md` へ誘導しました。

## 今回やらないこと
- 起動スクリプトの変更
- package変更
- CI変更
- アプリ実装変更
- 詳細な開発者向け説明の追加
- 長いFAQ化
- 個人PCの絶対パス記載
- secret / token / API key記載

## docs-only / scope外変更がないこと
- docs-onlyです。
- 変更は `README.md` のみです。
- `src/**`, `server/**`, `sample-games/**`, `samples/**`, `docs/**`, `public/**`, `package.json`, `package-lock.json`, `.github/**`, `start.*`, `start-sample-battle.*`, `.gitattributes` は変更していません。

## main追従状況
- PR作成前に `git fetch origin` を実行しました。
- 現在branchへ `origin/main` を取り込み済みです。
- conflictなしです。

## 確認結果
- `git diff --name-only origin/main...HEAD`: `README.md` のみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 初回はsandbox権限で esbuild `spawn EPERM`、通常権限の再実行で成功
- UI変更なしのため、PC幅 / 390px幅のブラウザ確認は対象外です。

## アカウント確認
- PR作成前に GitHub CLI の active account が `kitsunesavaskiy-dev` であることを確認しました。
- `SongDaZC` は active account ではありません。

## 監査役に見てほしい点
- 非技術者の初見ユーザーが最初の手順を短く追えるか
- `Download ZIP` と `start.bat` が主導線になっているか
- 個人パス、secret、token、API key が含まれていないか
- 変更scopeが `README.md` のみに閉じているか