### PR TITLE
feat: add tutorial guide overlay foundation

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -4,6 +4,7 @@ import { CommandConsole } from "../features/commands/CommandConsole";
 import { EventModal } from "../features/events/EventModal";
 import { FirstActionGuide } from "../features/onboarding/FirstActionGuide";
 import { WorldViewport } from "../features/sandbox/WorldViewport";
+import { TutorialGuideOverlay, type TutorialGuideStep } from "../features/tutorial/TutorialGuideOverlay";
 import { createMockProvider } from "../infrastructure/llm/mockProvider";
 import { createTemplateProvider } from "../infrastructure/llm/templateProvider";
 import {
@@ -32,6 +33,47 @@ interface AppShellProps {
 const UTTERANCE_PREVIEW_PROVIDERS = [
   { label: "mockProvider", provider: createMockProvider() },
   { label: "templateProvider", provider: createTemplateProvider() },
+];
+
+const APP_SHELL_TUTORIAL_STEPS: TutorialGuideStep[] = [
+  {
+    id: "observe-purpose",
+    title: "ここで何をするゲームかを見る",
+    body: "最初は、この案内カードで自分の現在地を確認します。新米神様として、箱庭の変化を見守る入口です。",
+    apostleLine: "まずは『自分は何を見る役か』を短く掴みましょう。ここが毎回の導線になります。",
+    targetLabel: "使徒の案内カード",
+    targetSelector: '[data-tutorial-anchor=\"first-action-guide\"]',
+    scrollBlock: "center",
+  },
+  {
+    id: "observe-world",
+    title: "箱庭そのものを見る",
+    body: "ここが住民たちが暮らす箱庭です。ドラッグしながら、誰がどこで動いているかを観察します。",
+    apostleLine: "大きな変化に気づく前に、まずは世界全体の様子を目で追ってみてください。",
+    targetLabel: "箱庭ビュー",
+    targetSelector: '[data-tutorial-anchor=\"world-viewport\"]',
+    highlightPadding: 18,
+    scrollBlock: "center",
+  },
+  {
+    id: "observe-next-action",
+    title: "次に押す場所を確認する",
+    body: "最初の操作は、この大きな CTA です。ここから少し時間を進めて、最初の変化を待てます。",
+    apostleLine: "初回は迷わなくて大丈夫です。次に触る場所だけを明るく示します。",
+    targetLabel: "FirstActionGuide の CTA",
+    targetSelector: '[data-tutorial-anchor=\"first-action-cta\"]',
+    scrollBlock: "center",
+  },
+  {
+    id: "observe-apostle-panel",
+    title: "変化を読む場所を確認する",
+    body: "使徒のメモや注目キャラの情報は、この右側パネルに集まります。後続 PBI ではここに Bless 本編の案内も差し込めます。",
+    apostleLine: "何が起きたか、誰を見ればよいかは、このパネルを起点に伝えます。",
+    targetLabel: "使徒パネル",
+    targetSelector: '[data-tutorial-anchor=\"apostle-panel\"]',
+    highlightPadding: 16,
+    scrollBlock: "center",
+  },
 ];
 
 export function AppShell({ userName, onLogout }: AppShellProps) {
@@ -117,7 +159,7 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
                 : "生存者なし"}
           </span>
         </div>
-        <div className="top-bar__controls">
+        <div className="top-bar__controls" data-tutorial-anchor="time-controls">
           <button
             className={`button button--ghost ${state.timeControl === "stopped" ? "button--active" : ""}`}
             disabled={state.phase === "event" || !hasLivingCharacters}
@@ -163,8 +205,10 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
         onStepTick={() => dispatch({ type: "stepTick" })}
       />
 
+      <TutorialGuideOverlay steps={APP_SHELL_TUTORIAL_STEPS} suspended={state.phase === "event"} />
+
       <main className="main-layout">
-        <section className="viewport-panel">
+        <section className="viewport-panel" data-tutorial-anchor="world-viewport">
           <WorldViewport
             characters={state.characters}
             focusCharacterId={state.focusCharacterId}
@@ -176,20 +220,22 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
         </section>
 
         <aside className="sidebar">
-          <ApostlePanel
-            apostleMessage={state.apostleMessage}
-            focusedCharacter={focusedCharacter}
-            characters={state.characters}
-            bloodlines={bloodlines}
-            latestEventSummary={state.latestEventSummary}
-            latestJudgement={state.latestJudgement}
-            momentum={state.momentum}
-            protectionRemaining={protectionRemaining}
-            hasLivingCharacters={hasLivingCharacters}
-            paused={state.phase === "event"}
-            onSelectCharacter={(characterId) => dispatch({ type: "selectFocus", characterId })}
-            onTriggerManualEvent={() => dispatch({ type: "triggerManualEvent" })}
-          />
+          <div data-tutorial-anchor="apostle-panel">
+            <ApostlePanel
+              apostleMessage={state.apostleMessage}
+              focusedCharacter={focusedCharacter}
+              characters={state.characters}
+              bloodlines={bloodlines}
+              latestEventSummary={state.latestEventSummary}
+              latestJudgement={state.latestJudgement}
+              momentum={state.momentum}
+              protectionRemaining={protectionRemaining}
+              hasLivingCharacters={hasLivingCharacters}
+              paused={state.phase === "event"}
+              onSelectCharacter={(characterId) => dispatch({ type: "selectFocus", characterId })}
+              onTriggerManualEvent={() => dispatch({ type: "triggerManualEvent" })}
+            />
+          </div>
 
           <UtterancePreviewPanel
             disabled={!hasLivingCharacters}

--- a/src/features/onboarding/FirstActionGuide.tsx
+++ b/src/features/onboarding/FirstActionGuide.tsx
@@ -56,7 +56,11 @@ export function FirstActionGuide({
   }, [isTutorialDismissed]);
 
   return (
-    <section className="first-action-guide" aria-labelledby="first-action-guide-title">
+    <section
+      className="first-action-guide"
+      aria-labelledby="first-action-guide-title"
+      data-tutorial-anchor="first-action-guide"
+    >
       <div className="first-action-guide__copy">
         <p className="first-action-guide__eyebrow">使徒の案内</p>
         <h2 id="first-action-guide-title">ここはAIキャラが暮らす箱庭です</h2>
@@ -80,14 +84,27 @@ export function FirstActionGuide({
         ) : null}
       </div>
 
-      <div className="first-action-guide__action-card first-action-guide__action-card--highlight" aria-label="次にすること">
+      <div
+        className="first-action-guide__action-card first-action-guide__action-card--highlight"
+        aria-label="次にすること"
+        data-tutorial-anchor="first-action-cta-card"
+      >
         <span className="first-action-guide__status">{guide.status}</span>
         {isEventOpen ? (
-          <div className="first-action-guide__cta first-action-guide__cta--notice">
+          <div
+            className="first-action-guide__cta first-action-guide__cta--notice"
+            data-tutorial-anchor="first-action-cta"
+          >
             {guide.ctaLabel}
           </div>
         ) : (
-          <button className="first-action-guide__cta" type="button" disabled={!canStep} onClick={onStepTick}>
+          <button
+            className="first-action-guide__cta"
+            type="button"
+            disabled={!canStep}
+            onClick={onStepTick}
+            data-tutorial-anchor="first-action-cta"
+          >
             {guide.ctaLabel}
           </button>
         )}

--- a/src/features/tutorial/TutorialGuideOverlay.css
+++ b/src/features/tutorial/TutorialGuideOverlay.css
@@ -1,0 +1,217 @@
+.tutorial-guide-overlay__launcher-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -0.15rem;
+}
+
+.tutorial-guide-overlay__launcher {
+  display: inline-flex;
+  gap: 0.55rem;
+  align-items: center;
+  border: 1px solid rgba(255, 217, 145, 0.22);
+  border-radius: 999px;
+  background: rgba(14, 24, 35, 0.82);
+  color: #f4f8fc;
+  padding: 0.62rem 0.86rem;
+}
+
+.tutorial-guide-overlay__launcher-text {
+  color: #9eb0c2;
+  font-size: 0.88rem;
+}
+
+.tutorial-guide-overlay {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+}
+
+.tutorial-guide-overlay__veil {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 10, 18, 0.66);
+}
+
+.tutorial-guide-overlay__spotlight {
+  position: fixed;
+  border: 1px solid rgba(255, 218, 145, 0.72);
+  border-radius: 20px;
+  box-shadow:
+    0 0 0 9999px rgba(4, 10, 18, 0.66),
+    0 0 0 10px rgba(255, 218, 145, 0.11),
+    0 20px 40px rgba(0, 0, 0, 0.28);
+}
+
+.tutorial-guide-overlay__bubble {
+  pointer-events: auto;
+  position: fixed;
+  display: grid;
+  gap: 0.8rem;
+  width: min(360px, calc(100vw - 32px));
+  max-height: min(70vh, 34rem);
+  overflow: auto;
+  border: 1px solid rgba(255, 218, 145, 0.26);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at top left, rgba(255, 218, 145, 0.14), transparent 40%),
+    linear-gradient(160deg, rgba(14, 24, 35, 0.98), rgba(8, 16, 26, 0.96));
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  color: #f3f7fb;
+  padding: 1rem;
+}
+
+.tutorial-guide-overlay__bubble::-webkit-scrollbar {
+  width: 0.45rem;
+}
+
+.tutorial-guide-overlay__bubble::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.tutorial-guide-overlay__header,
+.tutorial-guide-overlay__actions,
+.tutorial-guide-overlay__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.tutorial-guide-overlay__header {
+  justify-content: space-between;
+}
+
+.tutorial-guide-overlay__eyebrow,
+.tutorial-guide-overlay__progress,
+.tutorial-guide-overlay__target {
+  margin: 0;
+}
+
+.tutorial-guide-overlay__eyebrow {
+  color: #ffd991;
+  font-size: 0.77rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tutorial-guide-overlay__progress {
+  color: #9eb0c2;
+  font-size: 0.86rem;
+}
+
+.tutorial-guide-overlay__title,
+.tutorial-guide-overlay__body,
+.tutorial-guide-overlay__apostle,
+.tutorial-guide-overlay__target,
+.tutorial-guide-overlay__missing {
+  margin: 0;
+}
+
+.tutorial-guide-overlay__title {
+  font-size: 1.18rem;
+  line-height: 1.3;
+}
+
+.tutorial-guide-overlay__body,
+.tutorial-guide-overlay__target,
+.tutorial-guide-overlay__missing {
+  color: #d0dceb;
+  line-height: 1.65;
+}
+
+.tutorial-guide-overlay__apostle {
+  border: 1px solid rgba(255, 218, 145, 0.18);
+  border-radius: 16px;
+  background: rgba(255, 218, 145, 0.1);
+  color: #f3e8ca;
+  line-height: 1.6;
+  padding: 0.72rem 0.82rem;
+}
+
+.tutorial-guide-overlay__target strong {
+  color: #ffd991;
+}
+
+.tutorial-guide-overlay__actions {
+  justify-content: space-between;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.2rem;
+}
+
+.tutorial-guide-overlay__nav {
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
+.tutorial-guide-overlay__button {
+  min-height: 2.8rem;
+  white-space: nowrap;
+}
+
+.tutorial-guide-overlay__button--secondary {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tutorial-guide-overlay__button--secondary:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+@media (max-width: 860px) {
+  .tutorial-guide-overlay__bubble {
+    left: 12px !important;
+    right: 12px !important;
+    bottom: 12px !important;
+    top: auto !important;
+    width: auto;
+    max-height: min(48vh, 24rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .tutorial-guide-overlay__launcher-row {
+    justify-content: stretch;
+  }
+
+  .tutorial-guide-overlay__launcher {
+    width: 100%;
+    justify-content: space-between;
+    padding: 0.7rem 0.8rem;
+  }
+
+  .tutorial-guide-overlay__bubble {
+    gap: 0.72rem;
+    border-radius: 18px;
+    padding: 0.88rem;
+  }
+
+  .tutorial-guide-overlay__title {
+    font-size: 1.05rem;
+  }
+
+  .tutorial-guide-overlay__actions {
+    position: sticky;
+    bottom: -0.88rem;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+    background: linear-gradient(180deg, rgba(8, 16, 26, 0.08), rgba(8, 16, 26, 0.98) 28%);
+    margin: 0 -0.88rem -0.88rem;
+    padding: 0.85rem 0.88rem 0.88rem;
+    z-index: 1;
+  }
+
+  .tutorial-guide-overlay__nav {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .tutorial-guide-overlay__button {
+    width: 100%;
+  }
+}

--- a/src/features/tutorial/TutorialGuideOverlay.tsx
+++ b/src/features/tutorial/TutorialGuideOverlay.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import "./TutorialGuideOverlay.css";
+
+const TUTORIAL_DEFERRED_KEY = "godsandbox.tutorialGuideOverlayFoundation.deferred.v1";
+const TUTORIAL_COMPLETED_KEY = "godsandbox.tutorialGuideOverlayFoundation.completed.v1";
+const MOBILE_BUBBLE_BREAKPOINT = 860;
+
+export interface TutorialGuideStep {
+  id: string;
+  title: string;
+  body: string;
+  apostleLine: string;
+  targetLabel: string;
+  targetSelector?: string;
+  highlightPadding?: number;
+  scrollBlock?: ScrollLogicalPosition;
+}
+
+interface TutorialGuideOverlayProps {
+  steps: TutorialGuideStep[];
+  suspended?: boolean;
+}
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function readStoredFlag(key: string) {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(key) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredFlag(key: string, value: boolean) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (value) {
+      window.localStorage.setItem(key, "true");
+      return;
+    }
+
+    window.localStorage.removeItem(key);
+  } catch {
+    // localStorage が使えない環境では、そのセッションだけの状態で続行します。
+  }
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getTargetElement(step: TutorialGuideStep) {
+  if (!step.targetSelector || typeof document === "undefined") {
+    return null;
+  }
+
+  return document.querySelector<HTMLElement>(step.targetSelector);
+}
+
+function createSpotlightRect(rect: DOMRect, padding: number): SpotlightRect {
+  return {
+    top: Math.max(8, rect.top - padding),
+    left: Math.max(8, rect.left - padding),
+    width: Math.min(window.innerWidth - 16, rect.width + padding * 2),
+    height: Math.min(window.innerHeight - 16, rect.height + padding * 2),
+  };
+}
+
+function createBubbleStyle(spotlightRect: SpotlightRect | null): CSSProperties {
+  if (!spotlightRect || window.innerWidth <= MOBILE_BUBBLE_BREAKPOINT) {
+    return {
+      left: 12,
+      right: 12,
+      bottom: 12,
+    };
+  }
+
+  const bubbleWidth = Math.min(360, window.innerWidth - 32);
+  const bubbleHeight = 260;
+  const canPlaceRight = spotlightRect.left + spotlightRect.width + bubbleWidth + 28 <= window.innerWidth;
+  const left = canPlaceRight
+    ? spotlightRect.left + spotlightRect.width + 18
+    : clamp(spotlightRect.left, 16, window.innerWidth - bubbleWidth - 16);
+  const preferredTop = spotlightRect.top + spotlightRect.height + 18;
+  const top = preferredTop + bubbleHeight <= window.innerHeight
+    ? preferredTop
+    : clamp(spotlightRect.top - bubbleHeight - 18, 16, window.innerHeight - bubbleHeight - 16);
+
+  return {
+    top,
+    left,
+    width: bubbleWidth,
+  };
+}
+
+export function TutorialGuideOverlay({ steps, suspended = false }: TutorialGuideOverlayProps) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isDeferred, setIsDeferred] = useState(readStoredFlag(TUTORIAL_DEFERRED_KEY));
+  const [isCompleted, setIsCompleted] = useState(readStoredFlag(TUTORIAL_COMPLETED_KEY));
+  const [isHiddenForSession, setIsHiddenForSession] = useState(false);
+  const [spotlightRect, setSpotlightRect] = useState<SpotlightRect | null>(null);
+  const [bubbleStyle, setBubbleStyle] = useState<CSSProperties>({});
+  const highlightedElementRef = useRef<HTMLElement | null>(null);
+  const isOpen = !isCompleted && !isDeferred && !isHiddenForSession;
+  const activeStep = steps[stepIndex];
+  const isLastStep = stepIndex === steps.length - 1;
+
+  useEffect(() => {
+    return () => {
+      if (highlightedElementRef.current) {
+        delete highlightedElementRef.current.dataset.tutorialHighlighted;
+      }
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!isOpen || suspended || !activeStep) {
+      setSpotlightRect(null);
+      return;
+    }
+
+    let frameId = 0;
+    let timeoutId = 0;
+
+    const updateHighlight = () => {
+      const target = getTargetElement(activeStep);
+
+      if (highlightedElementRef.current && highlightedElementRef.current !== target) {
+        delete highlightedElementRef.current.dataset.tutorialHighlighted;
+      }
+
+      highlightedElementRef.current = target;
+
+      if (!target) {
+        setSpotlightRect(null);
+        setBubbleStyle(createBubbleStyle(null));
+        return;
+      }
+
+      target.dataset.tutorialHighlighted = "true";
+      const rect = target.getBoundingClientRect();
+      const nextSpotlightRect = createSpotlightRect(rect, activeStep.highlightPadding ?? 14);
+      setSpotlightRect(nextSpotlightRect);
+      setBubbleStyle(createBubbleStyle(nextSpotlightRect));
+    };
+
+    const target = getTargetElement(activeStep);
+    if (target) {
+      target.scrollIntoView({
+        behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+        block: activeStep.scrollBlock ?? (window.innerWidth <= MOBILE_BUBBLE_BREAKPOINT ? "center" : "nearest"),
+        inline: "nearest",
+      });
+    }
+
+    frameId = window.requestAnimationFrame(updateHighlight);
+    timeoutId = window.setTimeout(updateHighlight, 320);
+
+    const handleLayout = () => {
+      window.requestAnimationFrame(updateHighlight);
+    };
+
+    window.addEventListener("resize", handleLayout);
+    window.addEventListener("scroll", handleLayout, true);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.clearTimeout(timeoutId);
+      window.removeEventListener("resize", handleLayout);
+      window.removeEventListener("scroll", handleLayout, true);
+    };
+  }, [activeStep, isOpen, suspended]);
+
+  if (!activeStep) {
+    return null;
+  }
+
+  const handleOpen = () => {
+    setIsDeferred(false);
+    setIsHiddenForSession(false);
+    writeStoredFlag(TUTORIAL_DEFERRED_KEY, false);
+  };
+
+  const handleDefer = () => {
+    setIsDeferred(true);
+    setIsHiddenForSession(false);
+    writeStoredFlag(TUTORIAL_DEFERRED_KEY, true);
+  };
+
+  const handleSkip = () => {
+    setIsHiddenForSession(true);
+  };
+
+  const handleComplete = () => {
+    setIsCompleted(true);
+    setIsDeferred(false);
+    setIsHiddenForSession(false);
+    writeStoredFlag(TUTORIAL_COMPLETED_KEY, true);
+    writeStoredFlag(TUTORIAL_DEFERRED_KEY, false);
+  };
+
+  return (
+    <>
+      {!isCompleted && !isOpen && !suspended ? (
+        <div className="tutorial-guide-overlay__launcher-row">
+          <div className="tutorial-guide-overlay__launcher">
+            <span className="tutorial-guide-overlay__launcher-text">
+              {isDeferred ? "使徒ガイドはあとで見られるようにしています。" : "使徒ガイドを閉じています。"}
+            </span>
+            <button className="button button--ghost tutorial-guide-overlay__button" type="button" onClick={handleOpen}>
+              使徒ガイドを開く
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {isOpen && !suspended ? (
+        <div className="tutorial-guide-overlay" aria-live="polite">
+          {spotlightRect ? (
+            <div
+              className="tutorial-guide-overlay__spotlight"
+              aria-hidden="true"
+              style={{
+                top: spotlightRect.top,
+                left: spotlightRect.left,
+                width: spotlightRect.width,
+                height: spotlightRect.height,
+              }}
+            />
+          ) : (
+            <div className="tutorial-guide-overlay__veil" aria-hidden="true" />
+          )}
+
+          <section
+            className="tutorial-guide-overlay__bubble"
+            style={bubbleStyle}
+            role="dialog"
+            aria-labelledby="tutorial-guide-overlay-title"
+            aria-describedby="tutorial-guide-overlay-body"
+          >
+            <div className="tutorial-guide-overlay__header">
+              <p className="tutorial-guide-overlay__eyebrow">使徒ガイド</p>
+              <p className="tutorial-guide-overlay__progress">
+                {stepIndex + 1} / {steps.length}
+              </p>
+            </div>
+
+            <h2 id="tutorial-guide-overlay-title" className="tutorial-guide-overlay__title">
+              {activeStep.title}
+            </h2>
+
+            <p id="tutorial-guide-overlay-body" className="tutorial-guide-overlay__body">
+              {activeStep.body}
+            </p>
+
+            <p className="tutorial-guide-overlay__apostle">{activeStep.apostleLine}</p>
+            <p className="tutorial-guide-overlay__target">
+              <strong>見る場所:</strong> {activeStep.targetLabel}
+            </p>
+
+            {!spotlightRect ? (
+              <p className="tutorial-guide-overlay__missing">
+                この場所はまだ準備中です。後続 PBI で対象が増えても、同じ仕組みで差し替えできます。
+              </p>
+            ) : null}
+
+            <div className="tutorial-guide-overlay__actions">
+              <button
+                className="button button--ghost tutorial-guide-overlay__button tutorial-guide-overlay__button--secondary"
+                type="button"
+                onClick={handleDefer}
+              >
+                あとで見る
+              </button>
+
+              <button
+                className="button button--ghost tutorial-guide-overlay__button tutorial-guide-overlay__button--secondary"
+                type="button"
+                onClick={handleSkip}
+              >
+                スキップ
+              </button>
+
+              <div className="tutorial-guide-overlay__nav">
+                <button
+                  className="button button--ghost tutorial-guide-overlay__button tutorial-guide-overlay__button--secondary"
+                  type="button"
+                  disabled={stepIndex === 0}
+                  onClick={() => setStepIndex((current) => Math.max(0, current - 1))}
+                >
+                  戻る
+                </button>
+                <button
+                  className="button tutorial-guide-overlay__button"
+                  type="button"
+                  onClick={() => {
+                    if (isLastStep) {
+                      handleComplete();
+                      return;
+                    }
+
+                    setStepIndex((current) => Math.min(steps.length - 1, current + 1));
+                  }}
+                >
+                  {isLastStep ? "完了" : "次へ"}
+                </button>
+              </div>
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
## 対象PBI
- PBI-TUTORIAL-GUIDE-OVERLAY-FOUNDATION-001

## 対応Issue
- #197
- Closes #197

## 変更ファイル
- `src/app/AppShell.tsx`
- `src/features/onboarding/FirstActionGuide.tsx`
- `src/features/tutorial/TutorialGuideOverlay.tsx`
- `src/features/tutorial/TutorialGuideOverlay.css`

## 今回やったこと
- 使徒ガイドの overlay 基盤を追加し、対象要素を selector ベースでハイライトできるようにした
- `FirstActionGuide`、箱庭ビュー、最初の CTA、使徒パネルを対象にした step 定義を `AppShell` 側で差し込めるようにした
- ガイド吹き出しから `次へ / 戻る / スキップ / あとで見る` を操作できるようにした
- `あとで見る` と `完了` を localStorage に保存し、既存 key と衝突しない専用 key を使うようにした
- イベント中は overlay を自動で止め、既存 `EventModal` を邪魔しないようにした

## どの要素をハイライトできるか
- `FirstActionGuide` 全体
- `FirstActionGuide` の主要 CTA
- `WorldViewport` を含む箱庭ビュー
- `ApostlePanel` を含む使徒パネル
- 後続 PBI では `data-tutorial-anchor` を追加するだけで対象を増やせる

## 390px幅で邪魔になっていないか
- 390px 幅では吹き出しを画面下部のコンパクトな sheet として表示し、主要ボタンが画面外に出ないことを確認した
- CTA や箱庭ビューは暗幕の下でも位置が分かり、次に触る場所が埋もれないことを確認した
- `あとで見る` 後は小さな再開ランチャーだけを残し、通常操作を塞がないことを確認した

## 後続PBIがどう使えるか
- 初級 Bless チュートリアル本編では、step 配列へ `EventModal` や個別 CTA を足すだけで導線を増やせる
- 使徒の文言差し替え、ハイライト対象追加、完了条件の細分化を UI 基盤の上に積める
- selector が見つからない場合も fallback 文言で壊れず、実装途中の画面にも段階導入できる

## 今回やらないこと
- 初級 Bless チュートリアル本編の全実装
- domain event 変更
- Passport 外部利用チュートリアル
- 上級者向け AI 環境構築
- package 変更
- CI 変更
- 画像追加

## scope外変更がないこと
- PR diff は `src/app/**`, `src/features/onboarding/**`, `src/features/tutorial/**` の許可ファイルのみに閉じている
- `package.json`, `package-lock.json`, `.github/**`, `src/domain/**`, `src/application/**`, `public/**` は変更していない

## 確認結果
- `git diff --name-only origin/main...HEAD`
  - `src/app/AppShell.tsx`
  - `src/features/onboarding/FirstActionGuide.tsx`
  - `src/features/tutorial/TutorialGuideOverlay.tsx`
  - `src/features/tutorial/TutorialGuideOverlay.css`
- `git diff --check origin/main...HEAD` 成功
- `npm run typecheck` 成功
- `npm run build` 成功
- PC幅ブラウザ確認済み
- 390px幅ブラウザ確認済み

## 監査役に見てほしい点
- step の粒度が後続 Bless チュートリアル本編へ自然に拡張できるか
- 390px 幅での overlay と既存ガイドの重なり方が許容範囲か
- localStorage の defer / complete 挙動が Sprint6 の導線として妥当か