### PR TITLE
ui: 個体一覧から行動選択へ進む導線anchorを追加

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -65,7 +65,7 @@ const APP_SHELL_TUTORIAL_STEPS: TutorialGuideStep[] = [
     body: "右側の使徒パネルで代表キャラを選び、Bless を押すと最初の成功体験へ進めます。",
     apostleLine: "最初は Watch や Test に迷わなくて大丈夫です。まずは Bless で助ける流れを見てみましょう。",
     targetLabel: "使徒パネルの Bless ボタン",
-    targetSelector: '[data-tutorial-anchor=\"first-action-cta\"]',
+    targetSelector: '[data-tutorial-anchor=\"action-bless-button\"]',
     scrollBlock: "center",
   },
   {

--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -78,6 +78,21 @@ function getPortraitGuide(name?: string) {
   };
 }
 
+function getCharacterCardAnchor(character: Character) {
+  return character.id === "aki" ? "character-card-aki" : undefined;
+}
+
+function getActionAnchor(intervention: InterventionKind) {
+  switch (intervention) {
+    case "watch":
+      return "action-watch-button";
+    case "bless":
+      return "action-bless-button";
+    case "test":
+      return "action-test-button";
+  }
+}
+
 export function ApostlePanel({
   apostleMessage,
   focusedCharacter,
@@ -148,7 +163,7 @@ export function ApostlePanel({
         <p className="focus-action-panel__lead">
           まず1人を選ぶと、箱庭がその住民を追い、神様が次にできることを選べます。
         </p>
-        <div className="focus-character-picker" aria-label="生存中の代表キャラ">
+        <div className="focus-character-picker" aria-label="生存中の代表キャラ" data-tutorial-anchor="character-list">
           {livingCharacters.map((character) => (
             <button
               key={character.id}
@@ -160,6 +175,7 @@ export function ApostlePanel({
                 .filter(Boolean)
                 .join(" ")}
               disabled={paused}
+              data-tutorial-anchor={getCharacterCardAnchor(character)}
               onClick={() => onSelectCharacter(character.id)}
             >
               <span>{character.name}</span>
@@ -170,7 +186,7 @@ export function ApostlePanel({
           ))}
           {livingCharacters.length === 0 ? <span className="summary-note">選べる住民はいません。</span> : null}
         </div>
-        <div className="focus-action-panel__current">
+        <div className="focus-action-panel__current" data-tutorial-anchor="selected-character-summary">
           <strong>{focusedCharacter ? `${focusedCharacter.name}に何をしますか？` : "代表キャラを選んでください"}</strong>
           <span>
             {focusedCharacter
@@ -179,23 +195,29 @@ export function ApostlePanel({
           </span>
         </div>
         <div className="focus-action-panel__actions">
-          {CHARACTER_ACTIONS.map((action) => (
-            <button
-              key={action.intervention}
-              type="button"
-              className={`focus-action-button focus-action-button--${action.tone}`}
-              disabled={paused || !focusedCharacter}
-              data-tutorial-anchor={action.intervention === "bless" ? "first-action-cta" : undefined}
-              onClick={() => {
-                if (focusedCharacter) {
-                  onRequestCharacterAction(action.intervention, focusedCharacter.name);
-                }
-              }}
-            >
-              <span>{action.label}</span>
-              <small>{action.description}</small>
-            </button>
-          ))}
+          {CHARACTER_ACTIONS.map((action) => {
+            const actionAnchor = getActionAnchor(action.intervention);
+
+            return (
+              <button
+                key={action.intervention}
+                type="button"
+                className={`focus-action-button focus-action-button--${action.tone}`}
+                disabled={paused || !focusedCharacter}
+                data-tutorial-anchor={action.intervention === "bless" ? "first-action-cta" : actionAnchor}
+                onClick={() => {
+                  if (focusedCharacter) {
+                    onRequestCharacterAction(action.intervention, focusedCharacter.name);
+                  }
+                }}
+              >
+                <span data-tutorial-anchor={action.intervention === "bless" ? actionAnchor : undefined}>
+                  {action.label}
+                </span>
+                <small>{action.description}</small>
+              </button>
+            );
+          })}
         </div>
         <p className="focus-action-panel__note">
           iPhoneではダブルクリックではなく、このボタンから進めます。PCでは従来の操作も補助として使えます。

--- a/src/features/apostle/ApostlePanel.tsx
+++ b/src/features/apostle/ApostlePanel.tsx
@@ -204,16 +204,15 @@ export function ApostlePanel({
                 type="button"
                 className={`focus-action-button focus-action-button--${action.tone}`}
                 disabled={paused || !focusedCharacter}
-                data-tutorial-anchor={action.intervention === "bless" ? "first-action-cta" : actionAnchor}
+                data-tutorial-anchor={actionAnchor}
+                data-first-action-anchor={action.intervention === "bless" ? "first-action-cta" : undefined}
                 onClick={() => {
                   if (focusedCharacter) {
                     onRequestCharacterAction(action.intervention, focusedCharacter.name);
                   }
                 }}
               >
-                <span data-tutorial-anchor={action.intervention === "bless" ? actionAnchor : undefined}>
-                  {action.label}
-                </span>
+                <span>{action.label}</span>
                 <small>{action.description}</small>
               </button>
             );

--- a/src/features/sandbox/WorldViewport.tsx
+++ b/src/features/sandbox/WorldViewport.tsx
@@ -390,6 +390,7 @@ export function WorldViewport({ characters, focusCharacterId, dayPhase, paused, 
   return (
     <div
       className="viewport-root world-viewport world-viewport--guided"
+      data-tutorial-anchor="sandbox-viewport"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}


### PR DESCRIPTION
対象PBI: PBI-UI-CHARACTER-LIST-ACTION-ROUTE-001
対応Issue: #212
Closes #212
branch: feature/pbi-ui-character-list-action-route-001

## 変更ファイル
- src/app/AppShell.tsx
- src/features/apostle/ApostlePanel.tsx
- src/features/sandbox/WorldViewport.tsx

## 今回やったこと
- 代表キャラ一覧に Line 3 チュートリアル用の安定anchorを追加しました。
- Akiカード、選択中キャラサマリ、Watch / Bless / Test CTAに `data-tutorial-anchor` を追加しました。
- `action-watch-button` / `action-bless-button` / `action-test-button` はすべて実操作対象の `<button>` 本体に付けました。
- 箱庭viewportに `sandbox-viewport` anchorを追加しました。
- 既存の初回Blessチュートリアルは `action-bless-button` を参照するようにし、後方互換用に Bless ボタン本体へ `data-first-action-anchor="first-action-cta"` を残しました。
- iOS相当では単一タップでAkiを選び、Bless導線へ進めることを確認しました。

## 追加したtutorial anchor
- `character-list`
- `character-card-aki`
- `selected-character-summary`
- `action-watch-button`
- `action-bless-button`
- `action-test-button`
- `sandbox-viewport`

## 今回やらないこと
- tutorial overlay基盤の作り込み
- EventModal文言整理
- domainロジック変更
- Sandbox表示サイズ調整
- Passport schema変更
- package / CI変更

## scope外変更がないこと
- 変更は `src/features/apostle/**`、`src/features/sandbox/**`、既存チュートリアル参照先を更新するための最小 `src/app/AppShell.tsx` に閉じています。
- `src/domain/**`、`src/features/tutorial/**`、`src/features/events/**`、docs、package、CI、Passport schema は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 上記3ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
- PC幅ブラウザ確認: Aki選択、選択中サマリ、Watch / Bless / Test CTA、全anchor表示を確認
- 390px幅ブラウザ確認: CTAが画面外へ出ず、body横スクロールなしを確認
- 390px幅単一タップ確認: Akiカードをタップ後、Bless CTAをタップして `Aki に最初の加護を届けます` モーダルが開くことを確認
- 390px幅anchor確認: `action-watch-button` / `action-bless-button` / `action-test-button` がすべて `<button>` 本体を指すことを確認

## 監査役に見てほしい点
- Line 3 が参照するanchorが安定しているか
- `action-bless-button` が実操作ボタン本体を指しているか
- 既存の初回Bless導線が `action-bless-button` 参照で壊れていないか
- iOS相当で単一タップ + 明示CTAの主導線として読めるか
- scope外ファイルに変更が混ざっていないか