### PR TITLE
security: gitleaksをCIとローカル手順に追加

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,25 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,14 +12,22 @@ jobs:
   gitleaks:
     name: gitleaks
     runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: 8.30.1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Install gitleaks
+        run: |
+          curl -sSLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          grep "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" "gitleaks_${GITLEAKS_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
+          chmod +x gitleaks
+          ./gitleaks version
+
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+        run: ./gitleaks detect --source . --verbose --redact

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: gitleaks-protect
+        name: gitleaks protect staged changes
+        entry: gitleaks protect --staged --verbose --redact
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/docs/security/gitleaks-ci-precommit.md
+++ b/docs/security/gitleaks-ci-precommit.md
@@ -6,7 +6,8 @@
 ## CI で確認すること
 
 `.github/workflows/gitleaks.yml` で、pull request と `main` への push 時に gitleaks を実行します。
-検出結果に secret らしき値を残しにくくするため、gitleaks artifact upload は無効にしています。
+CI では pinned version の gitleaks CLI を GitHub Releases から取得し、checksum を確認してから実行します。
+検出結果に secret らしき値を残しにくくするため、CI では `--redact` を付けます。
 
 CI が失敗した場合は、次の順で対応します。
 

--- a/docs/security/gitleaks-ci-precommit.md
+++ b/docs/security/gitleaks-ci-precommit.md
@@ -1,0 +1,92 @@
+# gitleaks CI / local pre-commit guide
+
+この文書は、GodSandbox に secret / token / API key を混入させないための最小運用です。
+検出結果を共有する時も、secret の実値は PR 本文、Issue、docs、チャットに貼らないでください。
+
+## CI で確認すること
+
+`.github/workflows/gitleaks.yml` で、pull request と `main` への push 時に gitleaks を実行します。
+検出結果に secret らしき値を残しにくくするため、gitleaks artifact upload は無効にしています。
+
+CI が失敗した場合は、次の順で対応します。
+
+1. GitHub のログを開く。
+2. 検出箇所を確認する。
+3. secret の実値を PR 本文やコメントに貼らず、該当ファイルから削除する。
+4. 実値が本物の credential だった可能性がある場合は、無効化・再発行が必要なものとして扱う。
+5. 過去履歴に入っていた場合は、この PR では履歴 rewrite をしない。別の security follow-up として判断する。
+
+## ローカルで staged changes を確認する
+
+PR 前には、commit 予定の差分だけを先に確認します。
+
+```powershell
+git add <変更ファイル>
+gitleaks protect --staged --verbose --redact
+```
+
+`--redact` を付けることで、検出結果に secret らしき値そのものを出しにくくします。
+それでも raw log の共有は慎重に扱ってください。
+
+## pre-commit framework を使う場合
+
+`pre-commit` を使う環境では、次で hook を有効化できます。
+
+```powershell
+pre-commit install
+```
+
+この repo の `.pre-commit-config.yaml` は、local hook として次を実行します。
+
+```powershell
+gitleaks protect --staged --verbose --redact
+```
+
+この設定は、`gitleaks` がローカル環境の `PATH` にあることを前提にしています。
+`pre-commit` や `gitleaks` のインストール方法は、各開発者の環境に合わせて選んでください。
+
+## pre-commit を使わない場合
+
+framework を使わない場合も、PR 前に手動で同じ確認を実行します。
+
+```powershell
+git add <変更ファイル>
+gitleaks protect --staged --verbose --redact
+```
+
+現在の作業ツリーだけをざっと見る場合は、次も使えます。
+
+```powershell
+gitleaks detect --source . --no-git --redact
+```
+
+Git 履歴も含めて確認したい場合は、`--no-git` を外します。
+
+```powershell
+gitleaks detect --source . --redact
+```
+
+## false positive の扱い
+
+false positive に見えても、まずは「本当に secret ではない」と確認します。
+
+- 実値っぽい文字列は、可能なら明らかな placeholder に置き換える。
+- PR コメントには secret 値を貼らない。
+- 必要なら、redacted output、ファイル名、行番号、なぜ false positive と判断したかだけを共有する。
+- allowlist や ignore で抑制したい場合は、別途 security review 付きの follow-up PBI として扱う。
+
+## `.env` の扱い
+
+`.gitignore` では `.env` と `.env.*` を Git 管理しない方針です。
+共有してよいのは、実値を含まない `.env.example` だけです。
+
+`.env.example` にも API key、token、password、個人PCの絶対パスを書かないでください。
+
+## 今回やらないこと
+
+- TruffleHog の定期スキャン
+- GitHub Secret Scanning 設定変更
+- package 変更
+- アプリ実装変更
+- secret の再発行作業
+- 過去履歴の rewrite


### PR DESCRIPTION
対象PBI: PBI-SECURITY-GITLEAKS-CI-PRECOMMIT-001
対応Issue: #222
Closes #222
branch: security/pbi-security-gitleaks-ci-precommit-001

## 変更ファイル
- `.github/workflows/gitleaks.yml`
- `.pre-commit-config.yaml`
- `docs/security/gitleaks-ci-precommit.md`

## 今回やったこと
- pull request と `main` push で gitleaks を実行する GitHub Actions workflow を追加しました。
- `gitleaks/gitleaks-action@v2` は organization repo で license を要求したため、CIでは pinned version の gitleaks CLI をGitHub Releasesから取得し、checksum確認後に `gitleaks detect --source . --verbose --redact` を実行する形にしました。
- local pre-commit framework 向けに、staged changes を `gitleaks protect --staged --verbose --redact` で確認する設定を追加しました。
- pre-commit を使わない場合の手動コマンドも docs に整理しました。
- CI失敗時、false positive、secret検出時の対応方針を docs に整理しました。
- secret 実値を PR本文 / Issue / docs / チャットへ貼らない方針を明記しました。
- `.gitignore` は既に `.env` / `.env.*` を除外し、`.env.example` だけ許可する方針だったため変更していません。

## 今回やらないこと
- TruffleHog の定期スキャン
- GitHub Secret Scanning 設定変更
- package変更
- アプリ実装変更
- secret実値のdocs記載
- 過去履歴のrewrite

## scope外変更がないこと
- `src/**`、`server/**`、`sample-games/**`、`samples/**`、`public/art/**`、package、Passport schema は変更していません。
- README は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 上記3ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- `gitleaks detect --source . --no-git`: ローカルに `gitleaks` が未導入のため未実行
- `gitleaks protect --staged --verbose`: ローカルに `gitleaks` が未導入のため未実行
- `npm run typecheck`: 成功
- `npm run build`: 成功

## 監査役に見てほしい点
- PR / push で gitleaks が走る workflow として妥当か
- local pre-commit 設定が staged changes の検査に閉じているか
- secret実値を貼らない運用がdocsで明確か
- false positive / CI失敗時の対応方針が過剰に履歴rewriteへ踏み込んでいないか
- package / CI以外のアプリ実装へ踏み込んでいないか