### PR TITLE
security: TruffleHog scheduled secret sweepを追加

### DIFF
--- a/.github/workflows/trufflehog-scheduled-sweep.yml
+++ b/.github/workflows/trufflehog-scheduled-sweep.yml
@@ -1,0 +1,61 @@
+name: TruffleHog Secret Sweep
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 18 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  verified-secret-sweep:
+    name: verified secret history sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run TruffleHog verified history sweep
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          result_file="$(mktemp)"
+          trap 'rm -f "$result_file"' EXIT
+
+          set +e
+          docker run --rm \
+            --volume "$PWD:/repo:ro" \
+            --env GIT_CONFIG_COUNT=1 \
+            --env GIT_CONFIG_KEY_0=safe.directory \
+            --env GIT_CONFIG_VALUE_0=/repo \
+            trufflesecurity/trufflehog:latest \
+            git file:///repo \
+            --only-verified \
+            --fail \
+            --json > "$result_file"
+          exit_code=$?
+          set -e
+
+          if [ "$exit_code" -eq 0 ]; then
+            echo "TruffleHog completed: no verified secrets found."
+            exit 0
+          fi
+
+          finding_count="$(wc -l < "$result_file" | tr -d '[:space:]')"
+          if [ -z "$finding_count" ]; then
+            finding_count="unknown"
+          fi
+
+          if [ "$exit_code" -eq 183 ]; then
+            echo "::error::TruffleHog found ${finding_count} verified secret candidate(s). Secret values are intentionally not printed. Follow docs/security/trufflehog-scheduled-sweep.md."
+            exit 1
+          fi
+
+          echo "::error::TruffleHog sweep failed with exit code ${exit_code}. Secret output was not printed."
+          exit "$exit_code"

--- a/.github/workflows/trufflehog-scheduled-sweep.yml
+++ b/.github/workflows/trufflehog-scheduled-sweep.yml
@@ -3,7 +3,8 @@ name: TruffleHog Secret Sweep
 on:
   workflow_dispatch:
   schedule:
-    - cron: "37 18 * * 0"
+    # Sunday 15:00 UTC = Monday 00:00 JST.
+    - cron: "0 15 * * 0"
 
 permissions:
   contents: read
@@ -34,7 +35,7 @@ jobs:
             --env GIT_CONFIG_COUNT=1 \
             --env GIT_CONFIG_KEY_0=safe.directory \
             --env GIT_CONFIG_VALUE_0=/repo \
-            trufflesecurity/trufflehog:latest \
+            ghcr.io/trufflesecurity/trufflehog:3.94.3@sha256:8837fd74692f6da826b51bc008b6bcf0dd2d70d31d06792673872a235d9b7e39 \
             git file:///repo \
             --only-verified \
             --fail \

--- a/docs/security/trufflehog-scheduled-sweep.md
+++ b/docs/security/trufflehog-scheduled-sweep.md
@@ -17,7 +17,7 @@ workflow: `.github/workflows/trufflehog-scheduled-sweep.yml`
 実行タイミング:
 
 - `workflow_dispatch`: 必要な時に手動実行します。
-- `schedule`: 週1回の定期実行です。
+- `schedule`: 週1回、月曜00:00 JSTに相当する `0 15 * * 0` で定期実行します。
 
 このworkflowは `pull_request` では動かしません。
 
@@ -36,6 +36,14 @@ trufflehog git file://. --only-verified
 実際のworkflowでは、Docker上のリポジトリパスに合わせて `file:///repo` を使います。
 
 `--only-verified` を使い、TruffleHog が検証できた secret 候補を主対象にします。
+
+Docker image は `latest` を使わず、version tag と digest を固定します。
+
+現在は次を使います。
+
+```text
+ghcr.io/trufflesecurity/trufflehog:3.94.3@sha256:8837fd74692f6da826b51bc008b6bcf0dd2d70d31d06792673872a235d9b7e39
+```
 
 ## ログに secret 実値を出さない
 

--- a/docs/security/trufflehog-scheduled-sweep.md
+++ b/docs/security/trufflehog-scheduled-sweep.md
@@ -1,0 +1,83 @@
+# TruffleHog scheduled secret sweep
+
+PBI: `PBI-SECURITY-TRUFFLEHOG-SCHEDULED-SWEEP-001`
+
+この文書は、TruffleHog による定期または手動の secret 履歴スキャン運用をまとめます。
+
+## 目的
+
+Git履歴に残った有効な secret 候補を検出します。
+
+通常のPRごとに全履歴を重く検証するのではなく、週次の定期実行と手動実行で確認します。
+
+## workflow
+
+workflow: `.github/workflows/trufflehog-scheduled-sweep.yml`
+
+実行タイミング:
+
+- `workflow_dispatch`: 必要な時に手動実行します。
+- `schedule`: 週1回の定期実行です。
+
+このworkflowは `pull_request` では動かしません。
+
+PRの通常CIを重くしすぎないためです。
+
+## スキャン方針
+
+workflowでは、リポジトリ全履歴を checkout してから TruffleHog を実行します。
+
+目的は次のコマンド相当です。
+
+```sh
+trufflehog git file://. --only-verified
+```
+
+実際のworkflowでは、Docker上のリポジトリパスに合わせて `file:///repo` を使います。
+
+`--only-verified` を使い、TruffleHog が検証できた secret 候補を主対象にします。
+
+## ログに secret 実値を出さない
+
+Actionsログには secret 実値を出しません。
+
+workflowでは、TruffleHog のJSON出力を一時ファイルへ保存し、ログには中身を表示しません。
+
+verified secret 候補が見つかった場合も、ログに出すのは件数と対応案内だけです。
+
+PR本文、Issue、レビューコメントにも secret 実値を貼らないでください。
+
+## verified secret が出た時の対応
+
+1. ActionsログやPRに secret 実値を貼らない。
+2. まず該当サービス側で secret を失効またはローテーションする。
+3. 必要な担当者だけで、ローカルの安全な環境で再現確認する。
+4. 共有する場合は、secret 実値ではなく、検出種別、影響範囲、対応状況だけを書く。
+5. 露出範囲を確認し、必要なら履歴rewriteを別PBIとして判断する。
+6. ローテーション後にworkflowを再実行し、verified finding が消えたことを確認する。
+
+ローカルで再確認する場合も、出力ファイルをGit管理に入れないでください。
+
+例:
+
+```sh
+trufflehog git file://. --only-verified --json > ../trufflehog-local-results.json
+```
+
+この結果ファイルをPR、Issue、チャットへ貼らないでください。
+
+## 今回やらないこと
+
+- 毎PRでの全履歴検証
+- gitleaks導入
+- GitHub Secret Scanning設定変更
+- package変更
+- アプリ実装変更
+- 履歴rewrite
+
+## 運用メモ
+
+- verified secret は、検出後に失効またはローテーションするまで危険な可能性があります。
+- 先にsecretを無効化し、その後に原因調査を進めます。
+- 画像、ログ、スクリーンショットにも secret 実値を写さないでください。
+- 誤検知に見える場合でも、secret実値を公開せずに確認します。


### PR DESCRIPTION
対象PBI: PBI-SECURITY-TRUFFLEHOG-SCHEDULED-SWEEP-001
対応Issue: #221
Closes #221
branch: sec/pbi-trufflehog-scheduled-sweep-001

## 変更ファイル
- `.github/workflows/trufflehog-scheduled-sweep.yml`
- `docs/security/trufflehog-scheduled-sweep.md`

## 今回やったこと
- TruffleHog を `workflow_dispatch` と週次 `schedule` で実行する workflow を追加しました。
- `pull_request` では動かさず、通常PR CIを重くしない構成にしました。
- schedule を PO要望の週末24:00相当に合わせ、`cron: "0 15 * * 0"` にしました。
  - Sunday 15:00 UTC = Monday 00:00 JST です。
- `latest` image をやめ、GHCR の version tag + digest pin に変更しました。
  - `ghcr.io/trufflesecurity/trufflehog:3.94.3@sha256:8837fd74692f6da826b51bc008b6bcf0dd2d70d31d06792673872a235d9b7e39`
- full history checkout 後に、Docker上で `trufflehog git file:///repo --only-verified --fail --json` を実行する構成にしました。
- TruffleHogのJSON出力を一時ファイルへ逃がし、Actionsログにsecret実値を出さない方針にしました。
- verified secret が出た時の失効/ローテーション、実値を貼らない共有、再実行確認の手順をdocsへ追加しました。

## secret露出防止
- Actionsログにはfinding本文を表示しません。
- PR本文、Issue、レビューコメントへsecret実値を貼らない方針をdocsに明記しました。
- ローカル再確認結果もGit管理やチャット共有に入れない方針を明記しました。

## 今回やらないこと
- 毎PRでの全履歴検証
- gitleaks導入
- GitHub Secret Scanning設定変更
- package変更
- アプリ実装変更
- 履歴rewrite

## scope外変更がないこと
- 変更は `.github/workflows/trufflehog-scheduled-sweep.yml` と `docs/security/trufflehog-scheduled-sweep.md` のみに閉じています。
- `src/**`、`server/**`、`sample-games/**`、`samples/**`、`public/art/**`、`package.json`、`package-lock.json`、Passport schema は変更していません。

## main追従
- 最新 `origin/main` を取得し、branchへmerge済みです。
- 追従後もPR diffは対象2ファイルのみです。

## 確認結果
- `git diff --name-only origin/main...HEAD`: 対象2ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- workflow確認: schedule / pinned image / TruffleHog options の構造チェック成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
- GitHub `build`: SUCCESS
- GitHub `guard`: SUCCESS
- GitHub `gitleaks`: SUCCESS

## 監査役に見てほしい点
- workflowがPRごとの必須チェックになっていないか
- schedule が月曜00:00 JST相当になっているか
- TruffleHog image が `latest` ではなく version tag + digest pin になっているか
- secret実値をActionsログへ出さない構成になっているか
- verified secret検出時の対応手順が安全か
- protected path `.github/**` 変更として manual review 前提になっているか