### PR TITLE
fix: complete tutorial after first Bless result

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -73,11 +73,11 @@ const APP_SHELL_TUTORIAL_STEPS: TutorialGuideStep[] = [
     id: "press-bless",
     title: "最後に Bless を押して助ける",
     body: "今回は Bless が正解当てではなく、Aki を良い方向へ支える一手です。光っている Bless ボタンだけを押してください。",
-    apostleLine: "ここが最初の成功体験です。Bless を押すと、この案内は閉じて次の出来事に進みます。",
+    apostleLine: "ここが最初の成功体験です。Bless を押したあとは、結果が出た時点でこの案内が自然に終わります。",
     targetLabel: "Bless ボタン",
     targetAnchor: "action-bless-button",
     advanceMode: "targetClick",
-    completeOnTargetClick: true,
+    waitForExternalCompletion: true,
     scrollBlock: "center",
   },
 ];
@@ -126,6 +126,7 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
   const protectionRemaining = getStartupProtectionRemaining(state);
   const dayPhase = getDayPhase(state.tick);
   const season = getSeason(state.tick);
+  const tutorialBlessResolved = firstBlessTutorialCompleted || state.latestJudgement?.action === "bless";
 
   useEffect(() => {
     if (state.phase === "event" && !state.activeEvent) {
@@ -263,7 +264,11 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
         onStepTick={() => dispatch({ type: "stepTick" })}
       />
 
-      <TutorialGuideOverlay steps={APP_SHELL_TUTORIAL_STEPS} suspended={state.phase === "event"} />
+      <TutorialGuideOverlay
+        steps={APP_SHELL_TUTORIAL_STEPS}
+        completedSignal={tutorialBlessResolved}
+        suspended={state.phase === "event"}
+      />
 
       <main className="main-layout">
         <section className="viewport-panel" data-tutorial-anchor="world-viewport">

--- a/src/features/tutorial/TutorialGuideOverlay.css
+++ b/src/features/tutorial/TutorialGuideOverlay.css
@@ -49,6 +49,7 @@
   display: grid;
   place-items: center;
   z-index: 2;
+  background: transparent;
 }
 
 .tutorial-guide-overlay__bubble {
@@ -128,25 +129,29 @@
 .tutorial-guide-overlay__apostle-sprite-shell {
   display: grid;
   place-items: center;
-  width: 4.6rem;
-  height: 4.6rem;
-  min-width: 4.6rem;
-  border: 1px solid rgba(255, 218, 145, 0.2);
-  border-radius: 18px;
-  background:
-    radial-gradient(circle at 30% 30%, rgba(255, 218, 145, 0.18), transparent 52%),
-    linear-gradient(180deg, rgba(27, 39, 54, 0.98), rgba(14, 22, 33, 0.98));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  width: 4.2rem;
+  height: 4.2rem;
+  min-width: 4.2rem;
+  border-radius: 16px;
+  background: transparent;
+  box-shadow: none;
   overflow: hidden;
 }
 
 .tutorial-guide-overlay__apostle-sprite {
-  --tutorial-apostle-frame-width: 4rem;
-  --tutorial-apostle-frame-height: 4rem;
+  --tutorial-apostle-frame-width: 5.7rem;
+  --tutorial-apostle-frame-height: 5.7rem;
   width: var(--tutorial-apostle-frame-width);
   height: var(--tutorial-apostle-frame-height);
+  background-color: rgba(34, 58, 82, 0.72);
+  background-blend-mode: darken;
   background-repeat: no-repeat;
-  image-rendering: auto;
+  display: block;
+  overflow: visible;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 10px 18px rgba(4, 10, 18, 0.34));
+  transform: translate3d(0, -0.08rem, 0) scale(1.3);
+  transform-origin: center;
 }
 
 .tutorial-guide-overlay__title {
@@ -241,15 +246,16 @@
   }
 
   .tutorial-guide-overlay__apostle-sprite-shell {
-    width: 3.9rem;
-    height: 3.9rem;
-    min-width: 3.9rem;
-    border-radius: 16px;
+    width: 3.75rem;
+    height: 3.75rem;
+    min-width: 3.75rem;
+    border-radius: 14px;
   }
 
   .tutorial-guide-overlay__apostle-sprite {
-    --tutorial-apostle-frame-width: 3.35rem;
-    --tutorial-apostle-frame-height: 3.35rem;
+    --tutorial-apostle-frame-width: 5rem;
+    --tutorial-apostle-frame-height: 5rem;
+    transform: translate3d(0, -0.05rem, 0) scale(1.3);
   }
 
   .tutorial-guide-overlay__title {

--- a/src/features/tutorial/TutorialGuideOverlay.tsx
+++ b/src/features/tutorial/TutorialGuideOverlay.tsx
@@ -20,10 +20,12 @@ export interface TutorialGuideStep {
   scrollBlock?: ScrollLogicalPosition;
   advanceMode?: "manual" | "targetClick";
   completeOnTargetClick?: boolean;
+  waitForExternalCompletion?: boolean;
 }
 
 interface TutorialGuideOverlayProps {
   steps: TutorialGuideStep[];
+  completedSignal?: boolean;
   suspended?: boolean;
 }
 
@@ -99,7 +101,7 @@ function createGuideLayout(spotlightRect: SpotlightRect | null): GuideLayout {
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
   const compact = viewportWidth <= MOBILE_BUBBLE_BREAKPOINT;
-  const spriteSize = viewportWidth <= MOBILE_LAYOUT_BREAKPOINT ? 80 : 104;
+  const spriteSize = viewportWidth <= MOBILE_LAYOUT_BREAKPOINT ? 108 : 136;
 
   if (!spotlightRect) {
     return {
@@ -183,10 +185,10 @@ function createGuideLayout(spotlightRect: SpotlightRect | null): GuideLayout {
   };
 }
 
-export function TutorialGuideOverlay({ steps, suspended = false }: TutorialGuideOverlayProps) {
+export function TutorialGuideOverlay({ steps, completedSignal = false, suspended = false }: TutorialGuideOverlayProps) {
   const [stepIndex, setStepIndex] = useState(0);
   const [isDeferred, setIsDeferred] = useState(readStoredFlag(TUTORIAL_DEFERRED_KEY));
-  const [isCompleted, setIsCompleted] = useState(readStoredFlag(TUTORIAL_COMPLETED_KEY));
+  const [isCompleted, setIsCompleted] = useState(readStoredFlag(TUTORIAL_COMPLETED_KEY) || completedSignal);
   const [isHiddenForSession, setIsHiddenForSession] = useState(false);
   const [spotlightRect, setSpotlightRect] = useState<SpotlightRect | null>(null);
   const [bubbleStyle, setBubbleStyle] = useState<CSSProperties>({});
@@ -208,10 +210,18 @@ export function TutorialGuideOverlay({ steps, suspended = false }: TutorialGuide
       return isLastStep ? "完了" : "次へ";
     }
 
+    if (activeStep.waitForExternalCompletion) {
+      return "結果が出ると完了";
+    }
+
     return activeStep.completeOnTargetClick ? "対象を押すと完了" : "対象を押すと進む";
-  }, [activeStep.completeOnTargetClick, advanceMode, isLastStep]);
+  }, [activeStep.completeOnTargetClick, activeStep.waitForExternalCompletion, advanceMode, isLastStep]);
 
   const advanceFromTarget = () => {
+    if (activeStep.waitForExternalCompletion) {
+      return;
+    }
+
     if (activeStep.completeOnTargetClick || isLastStep) {
       handleComplete();
       return;
@@ -278,6 +288,20 @@ export function TutorialGuideOverlay({ steps, suspended = false }: TutorialGuide
       window.clearInterval(intervalId);
     };
   }, [apostleMotion, isOpen, isSpriteReady, suspended]);
+
+  useEffect(() => {
+    if (!completedSignal) {
+      return;
+    }
+
+    if (isCompleted) {
+      writeStoredFlag(TUTORIAL_COMPLETED_KEY, true);
+      writeStoredFlag(TUTORIAL_DEFERRED_KEY, false);
+      return;
+    }
+
+    handleComplete();
+  }, [completedSignal, isCompleted]);
 
   useLayoutEffect(() => {
     if (!isOpen || suspended || !activeStep) {
@@ -559,7 +583,12 @@ export function TutorialGuideOverlay({ steps, suspended = false }: TutorialGuide
 
             {isTargetInteractionStep ? (
               <p className="tutorial-guide-overlay__target-lock">
-                光っている対象だけが押せます。{activeStep.completeOnTargetClick ? "この操作で案内は完了します。" : "押すと次へ進みます。"}
+                光っている対象だけが押せます。
+                {activeStep.waitForExternalCompletion
+                  ? " Bless の結果が出た時点で案内は完了します。"
+                  : activeStep.completeOnTargetClick
+                    ? " この操作で案内は完了します。"
+                    : " 押すと次へ進みます。"}
               </p>
             ) : null}
 


### PR DESCRIPTION
## 対象PBI
- PBI-TUTORIAL-GUIDE-COMPLETE-AND-SPRITE-VISIBILITY-FIX-001

## 対応Issue
- #220
- Closes #220

## 変更ファイル
- `src/app/AppShell.tsx`
- `src/features/tutorial/TutorialGuideOverlay.tsx`
- `src/features/tutorial/TutorialGuideOverlay.css`

## 今回やったこと
- 初回 Bless でボタンを押した瞬間ではなく、結果表示が出たあとにチュートリアル完了扱いへ遷移するようにしました。
- チュートリアル完了後に overlay と操作ロックが解除され、通常操作へ戻れるようにしました。
- 使徒 sprite を以前より大きくしつつ、390px 幅でも Bless 導線や結果表示を覆いすぎない配置へ調整しました。
- sprite shell / guide 周辺の不要な白背景は持たせず、素材セルの白マットが UI 全体を強く塗りつぶさない一時表示へ寄せました。

## Bless結果後にチュートリアルが完了する確認結果
- 390px 幅の live harness で `Aki 選択 → Bless 押下 → 結果表示 → 確認` まで進め、tutorial overlay が消えることを確認しました。
- 完了後は `Reo` を選択でき、`Reo に何をしますか？` まで遷移できることを確認しました。

## 操作ロック解除の確認結果
- チュートリアル完了後は指定対象以外のロックが解除され、別キャラカードを通常通り押せることを確認しました。
- EventModal の結果表示中はチュートリアル overlay が残らず、結果確認を邪魔しないことを確認しました。

## 使徒sprite白背景を消した箇所
- `src/features/tutorial/TutorialGuideOverlay.css`
- `src/features/tutorial/TutorialGuideOverlay.tsx`

## 使徒spriteサイズ調整内容
- sprite 表示を以前より大きくし、セル余白をトリムして視認性を上げました。
- 390px 幅では shell を小さめに保ちつつ sprite 自体を拡大し、CTA と対象 UI の上に居座りすぎないバランスへ調整しました。

## 白背景について
- 白背景の根本原因は、現行 sprite 素材セル側に白マットが残っていることです。
- 今回は `public/art` を変更せず、CSS で完全透過化を追わずに、一時的な表示改善に留めています。
- 正式な透過 sprite 素材への差し替えは follow-up PBI に分けます。

## PC幅確認結果
- `tutorial-overlay-preview.html` の 1280px frame で、Aki 選択導線と Bless 導線が画面内に収まり、使徒 sprite が主要 CTA を大きく覆わないことを確認しました。

## 390px幅確認結果
- live harness で `Aki 選択 → Bless → 結果表示 → チュートリアル完了` まで確認しました。
- 使徒 sprite は小さすぎず、Bless ボタンや結果確認ボタンを隠しすぎないことを確認しました。

## scope外変更なし
- `src/domain/**` 変更なし
- `src/features/events/**` 変更なし
- `public/art/**` 変更なし
- package / CI / Passport schema 変更なし

## 確認結果
- `git diff --name-only origin/main...HEAD`
- `git diff --check origin/main...HEAD`
- `npm run typecheck`
- `npm run build`
- PC幅ブラウザ確認
- 390px幅ブラウザ確認