### PR TITLE
feat: villager立ち絵alpha化プロンプトbuilderを追加

### DIFF
--- a/src/features/villagerImport/alphaPrompt.ts
+++ b/src/features/villagerImport/alphaPrompt.ts
@@ -1,0 +1,64 @@
+export type VillagerAlphaPromptInput = {
+  characterName: string;
+};
+
+export type VillagerAlphaPromptResult = {
+  characterName: string;
+  assetName: string;
+  fileName: string;
+  savePath: string;
+  policyNotice: string;
+  prompt: string;
+};
+
+const DEFAULT_ASSET_NAME = "villager-character";
+
+export const VILLAGER_ALPHA_POLICY_NOTICE =
+  "画像を使う前に、著作権、転載可否、AI利用ポリシー、本人または権利者の許可を確認してください。secret、個人情報、許可のない画像は使わないでください。";
+
+export function normalizeVillagerAssetName(characterName: string): string {
+  const normalized = characterName
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-")
+    .replace(/\.+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return normalized || DEFAULT_ASSET_NAME;
+}
+
+export function buildVillagerAlphaPrompt(
+  input: VillagerAlphaPromptInput,
+): VillagerAlphaPromptResult {
+  const assetName = normalizeVillagerAssetName(input.characterName);
+  const fileName = `${assetName}.png`;
+  const savePath = `image/villager/${fileName}`;
+
+  const prompt = [
+    "You are preparing a game-ready transparent character asset for GodSandbox.",
+    "Use the attached image only as the identity reference.",
+    "Preserve the character's face, hair, outfit, colors, silhouette, and overall mood.",
+    "Remove the background completely.",
+    "Output a PNG with a real alpha channel.",
+    "The transparent area must be alpha 0.",
+    "Do not bake in a white background, green background, checkerboard background, shadow box, or scene background.",
+    "Do not leave a white matte, outline halo, or solid edge around the character.",
+    "Do not output JPEG.",
+    "Do not crop off the character.",
+    "Do not redesign the character.",
+    "Do not add text labels.",
+    `Save the result as: ${savePath}`,
+    "",
+    "Before generating, confirm that the user has the right to use this image and that using it with AI generation is allowed.",
+  ].join("\n");
+
+  return {
+    characterName: input.characterName.trim(),
+    assetName,
+    fileName,
+    savePath,
+    policyNotice: VILLAGER_ALPHA_POLICY_NOTICE,
+    prompt,
+  };
+}


### PR DESCRIPTION
対象PBI: PBI-VILLAGER-ALPHA-PROMPT-BUILDER-001
対応Issue: #230
Closes #230
branch: feature/pbi-villager-alpha-prompt-builder-001

## 変更ファイル
- `src/features/villagerImport/alphaPrompt.ts`

## 今回やったこと
- 立ち絵画像を別ブラウザのCodex画像生成へ貼るための、PNG alpha化プロンプトbuilderを追加しました。
- 入力画像を identity reference として扱い、顔、髪型、服装、色、雰囲気を維持する文言にしました。
- 背景削除、real alpha channel、alpha 0、JPEG禁止、白/緑/チェッカー背景焼き込み禁止、白マット禁止をpromptへ入れました。
- 保存先 `image/villager/<characterName>.png` を返すようにしました。
- 著作権、転載可否、AI利用ポリシー、本人または権利者の許可確認を促す注意文を追加しました。
- キャラクター名はファイルパス用に安全化し、空の場合は `villager-character` にfallbackします。

## 今回やらないこと
- 実画像生成
- Codex API連携
- ファイル保存
- sprite sheet生成
- GodSandbox本体UI接続
- package変更
- Passport schema変更

## scope外変更がないこと
- 変更は `src/features/villagerImport/alphaPrompt.ts` のみに閉じています。
- `src/domain/**`、`public/art/**`、`package.json`、`package-lock.json`、`.github/**`、Passport schema は変更していません。

## 確認結果
- `git diff --name-only origin/main...HEAD`: `src/features/villagerImport/alphaPrompt.ts` のみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功

## 監査役に見てほしい点
- promptがalpha付きPNG要件を明確に満たしているか
- アプリ内AI生成やAPI連携に踏み込んでいないか
- 著作物/転載/AI利用ポリシー確認の注意が十分か
- ファイル保存やsprite sheet生成へscopeが広がっていないか