### PR TITLE
feat: add villager alpha asset validation

### DIFF
--- a/src/features/villagerImport/VillagerImageAlphaValidationPanel.css
+++ b/src/features/villagerImport/VillagerImageAlphaValidationPanel.css
@@ -1,0 +1,160 @@
+.villager-alpha-validation {
+  display: grid;
+  gap: 1rem;
+}
+
+.villager-alpha-validation__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.villager-alpha-validation__header h2,
+.villager-alpha-validation__intro,
+.villager-alpha-validation__busy,
+.villager-alpha-validation__error,
+.villager-alpha-validation__placeholder p {
+  margin: 0;
+}
+
+.villager-alpha-validation__picker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.9rem;
+  border: 1px solid rgba(255, 217, 145, 0.22);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f7fb;
+  font-weight: 700;
+  padding: 0.78rem 1rem;
+  cursor: pointer;
+}
+
+.villager-alpha-validation__picker:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.villager-alpha-validation__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.villager-alpha-validation__intro,
+.villager-alpha-validation__busy,
+.villager-alpha-validation__placeholder,
+.villager-alpha-validation__error {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #d0dceb;
+  line-height: 1.65;
+  padding: 0.85rem 0.95rem;
+}
+
+.villager-alpha-validation__error {
+  border-color: rgba(255, 129, 129, 0.24);
+  background: rgba(146, 48, 48, 0.18);
+  color: #ffe0e0;
+}
+
+.villager-alpha-validation__result {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.villager-alpha-validation__facts {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.villager-alpha-validation__fact {
+  display: grid;
+  gap: 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.8rem 0.85rem;
+}
+
+.villager-alpha-validation__fact-label {
+  color: #9eb0c2;
+  font-size: 0.82rem;
+}
+
+.villager-alpha-validation__messages {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.villager-alpha-validation__message {
+  display: grid;
+  gap: 0.55rem;
+  border-radius: 16px;
+  line-height: 1.62;
+  padding: 0.85rem 0.95rem;
+}
+
+.villager-alpha-validation__message--error {
+  border: 1px solid rgba(255, 129, 129, 0.28);
+  background: rgba(146, 48, 48, 0.18);
+  color: #ffe6e6;
+}
+
+.villager-alpha-validation__message--warning {
+  border: 1px solid rgba(255, 217, 145, 0.24);
+  background: rgba(255, 217, 145, 0.1);
+  color: #f7ebcf;
+}
+
+.villager-alpha-validation__message--info {
+  border: 1px solid rgba(132, 210, 255, 0.22);
+  background: rgba(132, 210, 255, 0.1);
+  color: #d7f1ff;
+}
+
+.villager-alpha-validation__message-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-height: 1.8rem;
+  border-radius: 999px;
+  background: rgba(8, 16, 26, 0.26);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.65rem;
+}
+
+.villager-alpha-validation__placeholder {
+  display: grid;
+  gap: 0.65rem;
+}
+
+@media (max-width: 640px) {
+  .villager-alpha-validation__header {
+    align-items: stretch;
+  }
+
+  .villager-alpha-validation__picker {
+    width: 100%;
+  }
+
+  .villager-alpha-validation__facts {
+    grid-template-columns: 1fr;
+  }
+
+  .villager-alpha-validation__message {
+    padding: 0.8rem 0.85rem;
+  }
+}

--- a/src/features/villagerImport/VillagerImageAlphaValidationPanel.tsx
+++ b/src/features/villagerImport/VillagerImageAlphaValidationPanel.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState, type ChangeEvent } from "react";
+import {
+  formatCornerAlphaSummary,
+  formatRatioAsPercent,
+  sortValidationMessages,
+  summarizeEdgeBackgroundTone,
+  validateVillagerImageAlpha,
+  type VillagerImageAlphaValidationResult,
+} from "./imageAlphaValidation";
+import "./VillagerImageAlphaValidationPanel.css";
+
+interface VillagerImageAlphaValidationPanelProps {
+  initialResult?: VillagerImageAlphaValidationResult | null;
+  initialErrorMessage?: string | null;
+}
+
+function getFormatLabel(format: VillagerImageAlphaValidationResult["format"]) {
+  switch (format) {
+    case "png":
+      return "PNG";
+    case "jpeg":
+      return "JPEG";
+    default:
+      return "その他";
+  }
+}
+
+function getSeverityLabel(severity: "error" | "warning" | "info") {
+  switch (severity) {
+    case "error":
+      return "NG";
+    case "warning":
+      return "要確認";
+    default:
+      return "参考";
+  }
+}
+
+export function VillagerImageAlphaValidationPanel({
+  initialResult = null,
+  initialErrorMessage = null,
+}: VillagerImageAlphaValidationPanelProps) {
+  const [result, setResult] = useState<VillagerImageAlphaValidationResult | null>(initialResult);
+  const [errorMessage, setErrorMessage] = useState<string | null>(initialErrorMessage);
+  const [isInspecting, setIsInspecting] = useState(false);
+  const sortedMessages = useMemo(
+    () => (result ? sortValidationMessages(result.messages) : []),
+    [result],
+  );
+
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+
+    setResult(null);
+    setErrorMessage(null);
+
+    if (!file) {
+      return;
+    }
+
+    setIsInspecting(true);
+
+    try {
+      const nextResult = await validateVillagerImageAlpha(file);
+      setResult(nextResult);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "画像検査に失敗しました。");
+    } finally {
+      setIsInspecting(false);
+      event.target.value = "";
+    }
+  }
+
+  return (
+    <section className="villager-alpha-validation panel">
+      <div className="villager-alpha-validation__header">
+        <div>
+          <p className="eyebrow">villager import guard</p>
+          <h2>alpha 付き画像かを先に検査する</h2>
+        </div>
+        <label className="villager-alpha-validation__picker">
+          <input
+            accept="image/png,image/jpeg"
+            className="villager-alpha-validation__input"
+            onChange={handleFileChange}
+            type="file"
+          />
+          画像を選ぶ
+        </label>
+      </div>
+
+      <p className="villager-alpha-validation__intro">
+        箱庭に入れる前に、背景が透過されているかをざっくり検査します。PNG でも外周が全部不透明なら警告します。
+      </p>
+
+      {isInspecting ? <p className="villager-alpha-validation__busy">画像を検査しています…</p> : null}
+      {errorMessage ? <p className="villager-alpha-validation__error">{errorMessage}</p> : null}
+
+      {result ? (
+        <div className="villager-alpha-validation__result">
+          <div className="villager-alpha-validation__facts">
+            <div className="villager-alpha-validation__fact">
+              <span className="villager-alpha-validation__fact-label">形式</span>
+              <strong>{getFormatLabel(result.format)}</strong>
+            </div>
+            <div className="villager-alpha-validation__fact">
+              <span className="villager-alpha-validation__fact-label">サイズ</span>
+              <strong>
+                {result.width} x {result.height}
+              </strong>
+            </div>
+            <div className="villager-alpha-validation__fact">
+              <span className="villager-alpha-validation__fact-label">外周透過</span>
+              <strong>{formatRatioAsPercent(result.transparentEdgeRatio)}</strong>
+            </div>
+            <div className="villager-alpha-validation__fact">
+              <span className="villager-alpha-validation__fact-label">四隅 alpha</span>
+              <strong>{formatCornerAlphaSummary(result.cornerAlphaValues)}</strong>
+            </div>
+            <div className="villager-alpha-validation__fact">
+              <span className="villager-alpha-validation__fact-label">背景の気配</span>
+              <strong>{summarizeEdgeBackgroundTone(result)}</strong>
+            </div>
+          </div>
+
+          <ul className="villager-alpha-validation__messages">
+            {sortedMessages.map((message) => (
+              <li
+                className={`villager-alpha-validation__message villager-alpha-validation__message--${message.severity}`}
+                key={message.code}
+              >
+                <span className="villager-alpha-validation__message-badge">{getSeverityLabel(message.severity)}</span>
+                <span>{message.text}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <div className="villager-alpha-validation__placeholder">
+          <p>PNG は alpha を持てますが、白背景が焼き込まれていると箱庭で浮いて見えます。</p>
+          <p>JPEG はこの時点で NG と出します。Codex へは「alpha付きPNG」「背景を焼き込まない」と指定してください。</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/villagerImport/imageAlphaValidation.ts
+++ b/src/features/villagerImport/imageAlphaValidation.ts
@@ -1,0 +1,338 @@
+export type VillagerImageFormat = "png" | "jpeg" | "other";
+export type VillagerImageValidationSeverity = "error" | "warning" | "info";
+
+export interface VillagerImageValidationMessage {
+  code: string;
+  severity: VillagerImageValidationSeverity;
+  text: string;
+}
+
+export interface VillagerImageAlphaValidationResult {
+  fileName: string;
+  mimeType: string;
+  format: VillagerImageFormat;
+  width: number;
+  height: number;
+  sampledEdgePixels: number;
+  transparentEdgePixels: number;
+  transparentAnyPixels: number;
+  cornerAlphaValues: number[];
+  opaqueEdgeRatio: number;
+  transparentEdgeRatio: number;
+  transparentAnyRatio: number;
+  lightOpaqueEdgeRatio: number;
+  checkerLikeEdgeRatio: number;
+  hasAnyTransparency: boolean;
+  messages: VillagerImageValidationMessage[];
+}
+
+type EdgePixelSample = {
+  alpha: number;
+  red: number;
+  green: number;
+  blue: number;
+};
+
+const EDGE_SAMPLE_DEPTH = 3;
+const LIGHT_EDGE_THRESHOLD = 238;
+const CHECKER_LIGHT_MIN = 164;
+const CHECKER_LIGHT_MAX = 236;
+const CHECKER_CHROMA_DELTA = 16;
+
+function getFormatFromFile(file: File): VillagerImageFormat {
+  const mimeType = file.type.toLowerCase();
+  if (mimeType === "image/png") {
+    return "png";
+  }
+
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") {
+    return "jpeg";
+  }
+
+  const lowerName = file.name.toLowerCase();
+  if (lowerName.endsWith(".png")) {
+    return "png";
+  }
+
+  if (lowerName.endsWith(".jpg") || lowerName.endsWith(".jpeg")) {
+    return "jpeg";
+  }
+
+  return "other";
+}
+
+function isLightOpaquePixel(sample: EdgePixelSample) {
+  return (
+    sample.alpha >= 250 &&
+    sample.red >= LIGHT_EDGE_THRESHOLD &&
+    sample.green >= LIGHT_EDGE_THRESHOLD &&
+    sample.blue >= LIGHT_EDGE_THRESHOLD
+  );
+}
+
+function isCheckerLikeOpaquePixel(sample: EdgePixelSample) {
+  const brightness = (sample.red + sample.green + sample.blue) / 3;
+  const maxDelta = Math.max(
+    Math.abs(sample.red - sample.green),
+    Math.abs(sample.green - sample.blue),
+    Math.abs(sample.red - sample.blue),
+  );
+
+  return (
+    sample.alpha >= 250 &&
+    brightness >= CHECKER_LIGHT_MIN &&
+    brightness <= CHECKER_LIGHT_MAX &&
+    maxDelta <= CHECKER_CHROMA_DELTA
+  );
+}
+
+function getBrightness(sample: EdgePixelSample) {
+  return (sample.red + sample.green + sample.blue) / 3;
+}
+
+function buildEdgeSampleIndexes(width: number, height: number, depth: number) {
+  const indexes = new Set<number>();
+  const maxX = Math.max(0, width - 1);
+  const maxY = Math.max(0, height - 1);
+  const lastInset = Math.max(0, Math.min(depth - 1, Math.floor(Math.min(width, height) / 2)));
+
+  for (let inset = 0; inset <= lastInset; inset += 1) {
+    const top = inset;
+    const bottom = maxY - inset;
+    const left = inset;
+    const right = maxX - inset;
+
+    for (let x = left; x <= right; x += 1) {
+      indexes.add((top * width + x) * 4);
+      indexes.add((bottom * width + x) * 4);
+    }
+
+    for (let y = top; y <= bottom; y += 1) {
+      indexes.add((y * width + left) * 4);
+      indexes.add((y * width + right) * 4);
+    }
+  }
+
+  return Array.from(indexes);
+}
+
+function readCornerAlphas(data: Uint8ClampedArray, width: number, height: number) {
+  const corners = [
+    [0, 0],
+    [Math.max(0, width - 1), 0],
+    [0, Math.max(0, height - 1)],
+    [Math.max(0, width - 1), Math.max(0, height - 1)],
+  ] as const;
+
+  return corners.map(([x, y]) => data[(y * width + x) * 4 + 3] ?? 255);
+}
+
+function collectEdgeSamples(data: Uint8ClampedArray, width: number, height: number) {
+  return buildEdgeSampleIndexes(width, height, EDGE_SAMPLE_DEPTH).map((pixelIndex) => ({
+    red: data[pixelIndex] ?? 0,
+    green: data[pixelIndex + 1] ?? 0,
+    blue: data[pixelIndex + 2] ?? 0,
+    alpha: data[pixelIndex + 3] ?? 255,
+  }));
+}
+
+function countTransparentPixels(data: Uint8ClampedArray) {
+  let transparentPixels = 0;
+
+  for (let index = 3; index < data.length; index += 4) {
+    if ((data[index] ?? 255) < 250) {
+      transparentPixels += 1;
+    }
+  }
+
+  return transparentPixels;
+}
+
+function analyzeAlphaImageData(
+  file: File,
+  format: VillagerImageFormat,
+  width: number,
+  height: number,
+  data: Uint8ClampedArray,
+): VillagerImageAlphaValidationResult {
+  const totalPixelCount = Math.max(1, width * height);
+  const edgeSamples = collectEdgeSamples(data, width, height);
+  const sampledEdgePixels = Math.max(1, edgeSamples.length);
+  const transparentEdgePixels = edgeSamples.filter((sample) => sample.alpha < 250).length;
+  const transparentAnyPixels = countTransparentPixels(data);
+  const cornerAlphaValues = readCornerAlphas(data, width, height);
+  const lightOpaqueEdgePixels = edgeSamples.filter(isLightOpaquePixel).length;
+  const checkerLikeEdgePixels = edgeSamples.filter(isCheckerLikeOpaquePixel).length;
+  const messages: VillagerImageValidationMessage[] = [];
+
+  if (format === "jpeg") {
+    messages.push({
+      code: "jpeg-not-supported",
+      severity: "error",
+      text: "JPEG は透明背景を持てないため、このままでは箱庭取り込みに向きません。alpha 付き PNG を使ってください。",
+    });
+  } else if (format === "other") {
+    messages.push({
+      code: "unsupported-format",
+      severity: "error",
+      text: "この画像形式は今回の検査対象外です。alpha 付き PNG を選んでください。",
+    });
+  }
+
+  const opaqueEdgeRatio = (sampledEdgePixels - transparentEdgePixels) / sampledEdgePixels;
+  const transparentEdgeRatio = transparentEdgePixels / sampledEdgePixels;
+  const transparentAnyRatio = transparentAnyPixels / totalPixelCount;
+  const lightOpaqueEdgeRatio = lightOpaqueEdgePixels / sampledEdgePixels;
+  const checkerLikeEdgeRatio = checkerLikeEdgePixels / sampledEdgePixels;
+  const hasAnyTransparency = transparentAnyPixels > 0;
+
+  if (format === "png") {
+    if (!hasAnyTransparency) {
+      messages.push({
+        code: "missing-alpha",
+        severity: "warning",
+        text: "この画像は透明背景ではない可能性があります。alpha 付き PNG か確認してください。",
+      });
+    }
+
+    if (opaqueEdgeRatio >= 0.95 && cornerAlphaValues.every((alpha) => alpha >= 250)) {
+      messages.push({
+        code: "opaque-outer-edge",
+        severity: "warning",
+        text: "外周に透明領域が見つかりません。白い背景が画像として焼き込まれている可能性があります。",
+      });
+    }
+
+    if (lightOpaqueEdgeRatio >= 0.35) {
+      messages.push({
+        code: "light-background-baked",
+        severity: "warning",
+        text: "白い背景が画像として焼き込まれている可能性があります。Codex で「alpha付きPNG」「背景を焼き込まない」と指定して再生成してください。",
+      });
+    }
+
+    if (checkerLikeEdgeRatio >= 0.28) {
+      messages.push({
+        code: "checker-pattern-baked",
+        severity: "warning",
+        text: "チェッカー柄が画像として焼き込まれている可能性があります。透過プレビューではなく、alpha 付き PNG を書き出してください。",
+      });
+    }
+
+    if (messages.length === 0) {
+      messages.push({
+        code: "alpha-looks-usable",
+        severity: "info",
+        text: "外周の透明領域はありそうです。このまま箱庭向け候補として扱えます。",
+      });
+    }
+  }
+
+  return {
+    fileName: file.name,
+    mimeType: file.type,
+    format,
+    width,
+    height,
+    sampledEdgePixels,
+    transparentEdgePixels,
+    transparentAnyPixels,
+    cornerAlphaValues,
+    opaqueEdgeRatio,
+    transparentEdgeRatio,
+    transparentAnyRatio,
+    lightOpaqueEdgeRatio,
+    checkerLikeEdgeRatio,
+    hasAnyTransparency,
+    messages,
+  };
+}
+
+function loadImageFromFile(file: File) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(image);
+    };
+
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error("画像を読み込めませんでした。"));
+    };
+
+    image.src = objectUrl;
+  });
+}
+
+export async function validateVillagerImageAlpha(file: File): Promise<VillagerImageAlphaValidationResult> {
+  const format = getFormatFromFile(file);
+  const image = await loadImageFromFile(file);
+  const width = Math.max(1, image.naturalWidth || image.width || 1);
+  const height = Math.max(1, image.naturalHeight || image.height || 1);
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+
+  if (!context) {
+    throw new Error("画像検査用の Canvas を初期化できませんでした。");
+  }
+
+  context.clearRect(0, 0, width, height);
+  context.drawImage(image, 0, 0, width, height);
+  const imageData = context.getImageData(0, 0, width, height);
+
+  return analyzeAlphaImageData(file, format, width, height, imageData.data);
+}
+
+export function formatRatioAsPercent(ratio: number) {
+  return `${Math.round(ratio * 100)}%`;
+}
+
+export function formatCornerAlphaSummary(cornerAlphaValues: number[]) {
+  if (cornerAlphaValues.length === 0) {
+    return "-";
+  }
+
+  const minAlpha = Math.min(...cornerAlphaValues);
+  const maxAlpha = Math.max(...cornerAlphaValues);
+  return `${minAlpha} - ${maxAlpha}`;
+}
+
+export function summarizeEdgeBackgroundTone(result: VillagerImageAlphaValidationResult) {
+  if (result.lightOpaqueEdgeRatio >= 0.35) {
+    return "白背景が残っている可能性";
+  }
+
+  if (result.checkerLikeEdgeRatio >= 0.28) {
+    return "チェッカー柄が残っている可能性";
+  }
+
+  if (!result.hasAnyTransparency) {
+    return "透明領域が見つからない";
+  }
+
+  return "透過候補あり";
+}
+
+export function sortValidationMessages(messages: VillagerImageValidationMessage[]) {
+  const priority: Record<VillagerImageValidationSeverity, number> = {
+    error: 0,
+    warning: 1,
+    info: 2,
+  };
+
+  return [...messages].sort((left, right) => priority[left.severity] - priority[right.severity]);
+}
+
+export function describeOpaqueEdgeBlendRisk(edgeSamples: EdgePixelSample[]) {
+  if (edgeSamples.length === 0) {
+    return 0;
+  }
+
+  const brightEdgeCount = edgeSamples.filter((sample) => getBrightness(sample) >= 240 && sample.alpha >= 250).length;
+  return brightEdgeCount / edgeSamples.length;
+}

--- a/src/features/villagerImport/index.ts
+++ b/src/features/villagerImport/index.ts
@@ -1,0 +1,12 @@
+export { VillagerImageAlphaValidationPanel } from "./VillagerImageAlphaValidationPanel";
+export {
+  formatCornerAlphaSummary,
+  formatRatioAsPercent,
+  sortValidationMessages,
+  summarizeEdgeBackgroundTone,
+  validateVillagerImageAlpha,
+  type VillagerImageAlphaValidationResult,
+  type VillagerImageFormat,
+  type VillagerImageValidationMessage,
+  type VillagerImageValidationSeverity,
+} from "./imageAlphaValidation";


### PR DESCRIPTION
## 対象PBI
- PBI-VILLAGER-ALPHA-ASSET-VALIDATION-001

## 対応Issue
- #231
- Closes #231

## 変更ファイル
- `src/features/villagerImport/imageAlphaValidation.ts`
- `src/features/villagerImport/VillagerImageAlphaValidationPanel.tsx`
- `src/features/villagerImport/VillagerImageAlphaValidationPanel.css`
- `src/features/villagerImport/index.ts`

## 今回やったこと
- 画像形式を `PNG / JPEG / other` で判定する検査ロジックを追加しました。
- Canvas に読み込んだ画像から alpha を確認し、四隅と外周の透明有無をチェックするようにしました。
- 外周がほぼ全不透明、alpha が見つからない、白背景が焼き込まれている可能性、チェッカー柄が焼き込まれている可能性を初心者向け文言で警告できるようにしました。
- 最小 UI として `VillagerImageAlphaValidationPanel` を追加し、390px 幅でも warning が縦に読めるローカル CSS にしました。

## 今回やらないこと
- 自動背景除去
- AI生成
- ファイル保存
- sprite sheet 検査

## scope外変更なし
- `src/domain/**` 変更なし
- `public/art/**` 変更なし
- package / CI / Passport schema 変更なし

## 確認結果
- `git diff --name-only origin/main...HEAD`
- `git diff --check origin/main...HEAD`
- `npm run typecheck`
- `npm run build`
- ローカル preview で desktop / 390px warning 表示を確認

## 補足
- 今回の panel は `src/features/villagerImport/**` に閉じた最小 UI です。
- 390px 確認は未追跡の local preview helper で行っており、PR diff には含めていません。