### PR TITLE
ui: 新たな魂を転生させる画像選択導線を追加

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -6,6 +6,7 @@ import { FirstActionGuide } from "../features/onboarding/FirstActionGuide";
 import { AdvancedCodexWorkspacePanel } from "../features/agentWorkspace/AdvancedCodexWorkspacePanel";
 import { WorldViewport } from "../features/sandbox/WorldViewport";
 import { TutorialGuideOverlay, type TutorialGuideStep } from "../features/tutorial/TutorialGuideOverlay";
+import { VillagerReincarnationImportPanel } from "../features/villagerImport/VillagerReincarnationImportPanel";
 import { createMockProvider } from "../infrastructure/llm/mockProvider";
 import { createTemplateProvider } from "../infrastructure/llm/templateProvider";
 import {
@@ -308,6 +309,8 @@ export function AppShell({ userName, onLogout }: AppShellProps) {
           />
 
           <PassportExportPanel focusedCharacter={focusedCharacter} />
+
+          <VillagerReincarnationImportPanel focusedCharacterName={focusedCharacter?.name} />
 
           <AdvancedCodexWorkspacePanel focusedCharacter={focusedCharacter} />
 

--- a/src/features/villagerImport/VillagerReincarnationImportPanel.css
+++ b/src/features/villagerImport/VillagerReincarnationImportPanel.css
@@ -1,0 +1,154 @@
+.villager-import-panel {
+  border-color: rgba(112, 191, 165, 0.26);
+  background:
+    linear-gradient(135deg, rgba(112, 191, 165, 0.08), rgba(93, 137, 216, 0.07)),
+    rgba(8, 17, 28, 0.82);
+}
+
+.villager-import-panel__lead,
+.villager-import-panel__hint,
+.villager-import-panel__target p {
+  margin: 0;
+  color: #c7d8e7;
+  font-size: 0.92rem;
+}
+
+.villager-import-panel__body,
+.villager-import-panel__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.villager-import-panel__notice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid rgba(246, 196, 83, 0.26);
+  border-radius: 14px;
+  background: rgba(246, 196, 83, 0.1);
+  color: #ffe9a8;
+  padding: 0.85rem;
+}
+
+.villager-import-panel__notice span {
+  color: #f4dfaa;
+  font-size: 0.9rem;
+}
+
+.villager-import-panel__actions,
+.villager-import-panel__prompt-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.villager-import-panel__file-input {
+  display: none;
+}
+
+.villager-import-panel__selected {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: minmax(92px, 0.34fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.villager-import-panel__preview {
+  display: grid;
+  min-height: 132px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(146, 175, 199, 0.18);
+  border-radius: 16px;
+  background:
+    linear-gradient(45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+    rgba(7, 16, 24, 0.48);
+  background-position:
+    0 0,
+    0 8px;
+  background-size: 16px 16px;
+}
+
+.villager-import-panel__preview img {
+  display: block;
+  width: 100%;
+  max-height: 180px;
+  object-fit: contain;
+}
+
+.villager-import-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.villager-import-field span,
+.villager-import-panel__target span {
+  color: #aebfd0;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.villager-import-field input,
+.villager-import-panel__prompt {
+  width: 100%;
+  border: 1px solid rgba(146, 175, 199, 0.18);
+  border-radius: 12px;
+  background: rgba(7, 16, 24, 0.72);
+  color: #f4f7fb;
+  padding: 0.68rem 0.75rem;
+}
+
+.villager-import-panel__target {
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+  border: 1px solid rgba(112, 191, 165, 0.22);
+  border-radius: 14px;
+  background: rgba(112, 191, 165, 0.08);
+  padding: 0.75rem;
+}
+
+.villager-import-panel__target code {
+  overflow-wrap: anywhere;
+  border-radius: 10px;
+  background: rgba(4, 11, 18, 0.72);
+  color: #bff7e2;
+  padding: 0.48rem 0.55rem;
+}
+
+.villager-import-panel__copy-status {
+  min-height: 1.3em;
+  color: #9ab0c2;
+  font-size: 0.84rem;
+}
+
+.villager-import-panel__prompt {
+  min-height: 220px;
+  resize: vertical;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 560px) {
+  .villager-import-panel__actions,
+  .villager-import-panel__prompt-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .villager-import-panel__actions .button,
+  .villager-import-panel__prompt-actions .button {
+    width: 100%;
+  }
+
+  .villager-import-panel__selected {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .villager-import-panel__preview {
+    min-height: 180px;
+  }
+}

--- a/src/features/villagerImport/VillagerReincarnationImportPanel.tsx
+++ b/src/features/villagerImport/VillagerReincarnationImportPanel.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import "./VillagerReincarnationImportPanel.css";
+
+type CopyStatus = "idle" | "copied" | "selected" | "failed";
+
+const IMPORT_NOTICE =
+  "注: この機能はプレイヤーのデスクトップのCodexのAI画像生成機能を使います。通常のトークン枠内で利用可能ですが、著作物を扱う場合は制作者のAI利用や転載可否ポリシーを必ず確認してください。";
+
+function stripFileExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, "");
+}
+
+function makeSafeFileBaseName(name: string): string {
+  const safeName = name
+    .normalize("NFKC")
+    .trim()
+    .replace(/[\\/:*?"<>|]+/g, "_")
+    .replace(/\.+/g, "_")
+    .replace(/\s+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[-_]+|[-_]+$/g, "");
+
+  return safeName || "new_villager";
+}
+
+function buildReincarnationPrompt(characterName: string, targetPath: string, sourceImageName?: string): string {
+  const displayName = characterName.trim() || "新しい住民";
+  const sourceLine = sourceImageName
+    ? `- 元画像ファイル名: ${sourceImageName}`
+    : "- 元画像ファイル名: ユーザーが選んだ立ち絵画像";
+
+  return `あなたは GodSandbox のキャラクター画像生成を手伝う外部Codexです。
+
+目的:
+新米神様が選んだ1枚の立ち絵画像をもとに、箱庭へ転生する住民「${displayName}」の画像素材を作る準備をします。
+
+前提:
+- GodSandboxは、AIキャラクターが暮らす小さな箱庭を見守る育成サンドボックスです。
+- プレイヤーは新米神様です。
+- キャラクターは箱庭で暮らす住民です。
+- この作業はGodSandboxアプリの外で行います。アプリ内からCodex pet/APIは呼びません。
+
+入力:
+${sourceLine}
+- キャラクター名: ${displayName}
+
+大切にすること:
+- 元画像の同一人物感を維持してください。
+- 髪型、目、服装、色味、年齢感を大きく変えないでください。
+- 著作物を扱う場合は、制作者のAI利用や転載可否ポリシーを必ず確認してください。
+- 個人情報、ロゴ、文字、不要な背景を混ぜないでください。
+
+保存先:
+生成または整理した立ち絵は、次の場所に配置する想定です。
+
+${targetPath}
+
+注意:
+- この保存先はGodSandbox内で表示する目安です。固定の個人PCパスではありません。
+- 保存helperはまだ未接続です。必要に応じてユーザーが手動で配置してください。
+- 自動画像生成、sprite sheet生成、Passport schema変更は今回行いません。`;
+}
+
+interface VillagerReincarnationImportPanelProps {
+  focusedCharacterName?: string;
+}
+
+export function VillagerReincarnationImportPanel({ focusedCharacterName }: VillagerReincarnationImportPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasConsented, setHasConsented] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [characterName, setCharacterName] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!selectedFile) {
+      setPreviewUrl(null);
+      return undefined;
+    }
+
+    const nextPreviewUrl = URL.createObjectURL(selectedFile);
+    setPreviewUrl(nextPreviewUrl);
+
+    return () => URL.revokeObjectURL(nextPreviewUrl);
+  }, [selectedFile]);
+
+  const safeFileBaseName = useMemo(() => makeSafeFileBaseName(characterName), [characterName]);
+  const targetPath = `image/villager/${safeFileBaseName}.png`;
+  const generatedPrompt = useMemo(
+    () => buildReincarnationPrompt(characterName, targetPath, selectedFile?.name),
+    [characterName, selectedFile?.name, targetPath],
+  );
+
+  function openFilePicker() {
+    setHasConsented(true);
+    fileInputRef.current?.click();
+  }
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    setSelectedFile(file);
+    setCopyStatus("idle");
+
+    if (file) {
+      setCharacterName((current) => current || stripFileExtension(file.name));
+    }
+  }
+
+  async function copyPrompt() {
+    setCopyStatus("idle");
+
+    try {
+      await navigator.clipboard.writeText(generatedPrompt);
+      setCopyStatus("copied");
+    } catch {
+      if (!promptRef.current) {
+        setCopyStatus("failed");
+        return;
+      }
+
+      promptRef.current.focus();
+      promptRef.current.select();
+      setCopyStatus("selected");
+    }
+  }
+
+  function resetFlow() {
+    setHasConsented(false);
+    setSelectedFile(null);
+    setCharacterName("");
+    setCopyStatus("idle");
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  return (
+    <section className="panel villager-import-panel" aria-labelledby="villager-import-title">
+      <div className="panel__heading">
+        <div>
+          <p className="eyebrow">reincarnation / optional</p>
+          <h2 id="villager-import-title">新たな魂を転生させる</h2>
+        </div>
+        <button className="button button--ghost" onClick={() => setIsOpen((current) => !current)}>
+          {isOpen ? "閉じる" : "新たな魂を転生させる"}
+        </button>
+      </div>
+
+      <p className="villager-import-panel__lead">
+        手元の立ち絵画像を選び、別ブラウザのCodexへ貼るための生成プロンプトと保存先を準備します。
+        この画面からCodex pet/APIは直接呼びません。
+      </p>
+
+      {isOpen ? (
+        <div className="villager-import-panel__body">
+          <div className="villager-import-panel__notice" role="note">
+            <strong>ファイルを箱庭にインポートしますか？</strong>
+            <span>{IMPORT_NOTICE}</span>
+          </div>
+
+          <div className="villager-import-panel__actions">
+            <button className="button" onClick={openFilePicker}>
+              承諾して画像を選ぶ
+            </button>
+            <button className="button button--ghost" onClick={resetFlow}>
+              入力をリセット
+            </button>
+          </div>
+
+          <input
+            ref={fileInputRef}
+            className="villager-import-panel__file-input"
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+          />
+
+          <p className="villager-import-panel__hint">
+            {hasConsented
+              ? "標準のファイル選択UIで画像を選びます。個人PCの絶対パスは画面にもGit管理にも保存しません。"
+              : "著作物の扱いを確認してから、画像選択へ進んでください。"}
+          </p>
+
+          {selectedFile ? (
+            <div className="villager-import-panel__selected">
+              <div className="villager-import-panel__preview">
+                {previewUrl ? <img src={previewUrl} alt="選択した立ち絵プレビュー" /> : null}
+              </div>
+
+              <div className="villager-import-panel__form">
+                <label className="villager-import-field">
+                  <span>このキャラクターの名前</span>
+                  <input
+                    value={characterName}
+                    onChange={(event) => {
+                      setCharacterName(event.target.value);
+                      setCopyStatus("idle");
+                    }}
+                    placeholder={focusedCharacterName ?? "Aki"}
+                  />
+                </label>
+
+                <div className="villager-import-panel__target">
+                  <span>保存先の目安</span>
+                  <code>{targetPath}</code>
+                  <p>
+                    保存helperはまだ未接続です。生成後の画像は、Line 4の保存helperに接続されるまでは
+                    この保存先に配置してください。
+                  </p>
+                </div>
+
+                <div className="villager-import-panel__prompt-actions">
+                  <button className="button" onClick={copyPrompt}>
+                    Codex用プロンプトをコピー
+                  </button>
+                  <span role="status" className="villager-import-panel__copy-status">
+                    {copyStatus === "copied"
+                      ? "コピーしました"
+                      : copyStatus === "selected"
+                        ? "自動コピーできなかったため、プロンプト本文を選択しました。Ctrl+C / ⌘Cでコピーしてください。"
+                        : copyStatus === "failed"
+                          ? "コピーできませんでした。下の本文を手動で選択してください。"
+                          : " "}
+                  </span>
+                </div>
+
+                <textarea
+                  ref={promptRef}
+                  className="villager-import-panel__prompt"
+                  readOnly
+                  value={generatedPrompt}
+                  aria-label="別ブラウザのCodexへ貼る転生準備プロンプト"
+                />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/villagerImport/VillagerReincarnationImportPanel.tsx
+++ b/src/features/villagerImport/VillagerReincarnationImportPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { buildVillagerAlphaPrompt } from "./alphaPrompt";
 import "./VillagerReincarnationImportPanel.css";
 
 type CopyStatus = "idle" | "copied" | "selected" | "failed";
@@ -10,20 +11,7 @@ function stripFileExtension(fileName: string): string {
   return fileName.replace(/\.[^.]+$/, "");
 }
 
-function makeSafeFileBaseName(name: string): string {
-  const safeName = name
-    .normalize("NFKC")
-    .trim()
-    .replace(/[\\/:*?"<>|]+/g, "_")
-    .replace(/\.+/g, "_")
-    .replace(/\s+/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^[-_]+|[-_]+$/g, "");
-
-  return safeName || "new_villager";
-}
-
-function buildReincarnationPrompt(characterName: string, targetPath: string, sourceImageName?: string): string {
+function buildReincarnationPrompt(characterName: string, alphaPrompt: string, sourceImageName?: string): string {
   const displayName = characterName.trim() || "新しい住民";
   const sourceLine = sourceImageName
     ? `- 元画像ファイル名: ${sourceImageName}`
@@ -50,15 +38,13 @@ ${sourceLine}
 - 著作物を扱う場合は、制作者のAI利用や転載可否ポリシーを必ず確認してください。
 - 個人情報、ロゴ、文字、不要な背景を混ぜないでください。
 
-保存先:
-生成または整理した立ち絵は、次の場所に配置する想定です。
-
-${targetPath}
+Codexへ貼る透明PNG生成指示:
+${alphaPrompt}
 
 注意:
-- この保存先はGodSandbox内で表示する目安です。固定の個人PCパスではありません。
-- 保存helperはまだ未接続です。必要に応じてユーザーが手動で配置してください。
-- 自動画像生成、sprite sheet生成、Passport schema変更は今回行いません。`;
+- 保存先は上の生成指示に含まれる repo 内の論理パスです。固定の個人PCパスではありません。
+- File System Access API が使えない場合は、必要に応じてユーザーが手動で配置してください。
+- Codex pet/APIのアプリ内直接呼び出し、自動画像生成、sprite sheet生成、Passport schema変更は今回行いません。`;
 }
 
 interface VillagerReincarnationImportPanelProps {
@@ -87,11 +73,11 @@ export function VillagerReincarnationImportPanel({ focusedCharacterName }: Villa
     return () => URL.revokeObjectURL(nextPreviewUrl);
   }, [selectedFile]);
 
-  const safeFileBaseName = useMemo(() => makeSafeFileBaseName(characterName), [characterName]);
-  const targetPath = `image/villager/${safeFileBaseName}.png`;
+  const alphaPromptResult = useMemo(() => buildVillagerAlphaPrompt({ characterName }), [characterName]);
+  const targetPath = alphaPromptResult.savePath;
   const generatedPrompt = useMemo(
-    () => buildReincarnationPrompt(characterName, targetPath, selectedFile?.name),
-    [characterName, selectedFile?.name, targetPath],
+    () => buildReincarnationPrompt(characterName, alphaPromptResult.prompt, selectedFile?.name),
+    [alphaPromptResult.prompt, characterName, selectedFile?.name],
   );
 
   function openFilePicker() {
@@ -208,8 +194,8 @@ export function VillagerReincarnationImportPanel({ focusedCharacterName }: Villa
                   <span>保存先の目安</span>
                   <code>{targetPath}</code>
                   <p>
-                    保存helperはまだ未接続です。生成後の画像は、Line 4の保存helperに接続されるまでは
-                    この保存先に配置してください。
+                    PR #236 の file placement helper と同じ論理保存先です。このパネルからは自動保存せず、
+                    生成後のPNGをこの保存先に配置してください。
                   </p>
                 </div>
 

--- a/src/features/villagerImport/alphaPrompt.ts
+++ b/src/features/villagerImport/alphaPrompt.ts
@@ -1,3 +1,5 @@
+import { getVillagerLogicalPath, toVillagerPngFileName } from "./filePlacement";
+
 export type VillagerAlphaPromptInput = {
   characterName: string;
 };
@@ -32,8 +34,8 @@ export function buildVillagerAlphaPrompt(
   input: VillagerAlphaPromptInput,
 ): VillagerAlphaPromptResult {
   const assetName = normalizeVillagerAssetName(input.characterName);
-  const fileName = `${assetName}.png`;
-  const savePath = `image/villager/${fileName}`;
+  const fileName = toVillagerPngFileName(input.characterName);
+  const savePath = getVillagerLogicalPath(input.characterName);
 
   const prompt = [
     "You are preparing a game-ready transparent character asset for GodSandbox.",
@@ -42,7 +44,8 @@ export function buildVillagerAlphaPrompt(
     "Remove the background completely.",
     "Output a PNG with a real alpha channel.",
     "The transparent area must be alpha 0.",
-    "Do not bake in a white background, green background, checkerboard background, shadow box, or scene background.",
+    "Do not bake white / green / checkerboard background into the image.",
+    "Do not bake in a shadow box or scene background.",
     "Do not leave a white matte, outline halo, or solid edge around the character.",
     "Do not output JPEG.",
     "Do not crop off the character.",


### PR DESCRIPTION
対象PBI: PBI-VILLAGER-REINCARNATION-IMPORT-UI-001
対応Issue: #232
Closes #232
branch: feature/pbi-villager-reincarnation-import-ui-001

## 変更ファイル
- `src/app/AppShell.tsx`
- `src/features/villagerImport/VillagerReincarnationImportPanel.tsx`
- `src/features/villagerImport/VillagerReincarnationImportPanel.css`
- `src/features/villagerImport/alphaPrompt.ts`

## 今回やったこと
- 箱庭UIのサイドバーに「新たな魂を転生させる」入口を追加しました。
- 入口を開くと、著作物/AI利用ポリシー確認の注意文を表示します。
- 承諾後に標準の画像ファイル選択UIを開く導線を追加しました。
- 画像選択後に「このキャラクターの名前」を入力できるようにしました。
- PR #233 で追加済みの `buildVillagerAlphaPrompt()` に、UIからコピーされるプロンプト生成を寄せました。
- PR #236 の file placement helper と同じ論理保存先を使うように、`alphaPrompt.ts` 側で `getVillagerLogicalPath()` / `toVillagerPngFileName()` を参照しました。
- 別ブラウザのCodexへ貼るための転生準備プロンプトを生成・コピーできるようにしました。
- コピーされるプロンプトに、透明PNG向けの `real alpha channel`、`transparent area alpha 0`、`Do not output JPEG`、`Do not bake white / green / checkerboard background`、`Do not leave white matte` 相当の指示を含めました。

## 今回やらないこと
- Codex pet/APIをアプリ内から直接呼ぶこと
- 自動画像生成
- sprite sheet生成
- Passport schema変更
- package変更
- 任意Windows固定パスへの無断書き込み
- `public/art/**` への画像追加

## scope外変更がないこと
- 変更は許可範囲の `src/app/AppShell.tsx` と `src/features/villagerImport/**` に閉じています。
- `src/domain/**`、`package.json`、`package-lock.json`、`.github/**`、`public/art/**`、`docs/**`、Passport schema は変更していません。
- 個人PCの絶対パス、secret、API key、token は追加していません。

## 確認結果
- 最新 `origin/main` (`87b3212`) を取り込み済み
- `git diff --name-only origin/main...HEAD`: 上記4ファイルのみ
- `git diff --check origin/main...HEAD`: 成功
- `npm run typecheck`: 成功
- `npm run build`: 成功
- GitHub `build` / `guard` / `gitleaks`: 成功
- PC幅ブラウザ確認: 1366pxで注意文、Codex pet/API未接続表記、`image/*` file input、横はみ出しなしを確認
- 390px幅ブラウザ確認: 注意文、Codex pet/API未接続表記、`image/*` file input、横はみ出しなしを確認
- 390px幅の画像選択後確認: 合成画像 `Aki.png` で名前 `Aki`、保存先 `image/villager/Aki.png`、配置案内、Codex用プロンプト導線を確認

## 監査役に見てほしい点
- `VillagerReincarnationImportPanel` が `buildVillagerAlphaPrompt()` を使う形に寄っていること
- コピーされるプロンプトに透明PNG/alpha channelの必須指示が入っていること
- Codex pet/APIをアプリ内から直接呼んでいないこと
- 著作物/AI利用ポリシー注意が十分に見えること
- 保存先が固定個人パスではなく `image/villager/<characterName>.png` の相対的な目安になっていること
- 390px幅でボタンと確認文が見切れていないこと
